### PR TITLE
upgrade fern to `0.8.5` to handle nullable

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.7.4"
+  "version": "0.8.5"
 }

--- a/fern/staging/generators.yml
+++ b/fern/staging/generators.yml
@@ -2,7 +2,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.5.17
+        version: 0.5.18
         # TODO(vellum): configure publish to private coordinate
         # output:
         #   location: npm


### PR DESCRIPTION
This PR upgrades fern (by running `fern upgrade`). The newest version of Fern contains a fix(https://github.com/fern-api/fern/pull/1528) so that `nullable` schemas are treated as optional. 