### PR TITLE
Upgrade prod python generator to 0.3.5

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -40,7 +40,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node
       - name: fernapi/fern-python-sdk
-        version: 0.3.3
+        version: 0.3.5
         output:
           location: pypi
           package-name: vellum-ai


### PR DESCRIPTION
With this upgrade, the README on https://github.com/vellum-ai/vellum-client-python will get mirrored to the PyPI package: https://pypi.org/project/vellum-ai/