### PR TITLE
add `streaming_generate` endpoint

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -14,7 +14,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node-staging
       - name: fernapi/fern-python-sdk
-        version: 0.3.6-rc1
+        version: 0.3.6-rc8
         # TODO(vellum): configure publish to private coordinate
         # output:
         #   location: pypi
@@ -40,7 +40,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node
       - name: fernapi/fern-python-sdk
-        version: 0.3.6-rc1
+        version: 0.3.6-rc8
         output:
           location: pypi
           package-name: vellum-ai

--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -130,6 +130,45 @@ paths:
       servers:
         - url: https://predict.vellum.ai
           x-name: Predict
+  /v1/generate-stream:
+    post:
+      operationId: generate_stream
+      tags:
+      - generate-stream
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateBodyRequest'
+        required: true
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateStreamResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateErrorResponse'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateErrorResponse'
+          description: ''
+      x-fern-streaming: true
   /v1/model-versions/{id}:
     get:
       operationId: model_versions_retrieve
@@ -649,6 +688,34 @@ components:
           description: The error message returned by the LLM provider.
       required:
       - message
+    GenerateStreamResponse:
+      type: object
+      properties:
+        delta:
+          $ref: '#/components/schemas/GenerateStreamResult'
+      required:
+      - delta
+    GenerateStreamResult:
+      type: object
+      properties:
+        request_index:
+          type: integer
+        data:
+          $ref: '#/components/schemas/GenerateStreamResultData'
+        error:
+          $ref: '#/components/schemas/GenerateResultError'
+      required:
+      - request_index
+    GenerateStreamResultData:
+      type: object
+      properties:
+        completion_index:
+          type: integer
+        completion:
+          $ref: '#/components/schemas/EnrichedNormalizedCompletion'
+      required:
+      - completion
+      - completion_index
     IndexingStateEnum:
       enum:
       - AWAITING_PROCESSING


### PR DESCRIPTION
1/ Updates `openapi.yml` to contain streaming_generate endpoint 
2/ Upgrades the Python generator to [0.3.6-rc8](https://github.com/fern-api/fern-python/releases/tag/0.3.6-rc8) which supports http streaming