### PR TITLE
add staging url for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,17 @@ jobs:
       - name: Download Fern
         run: npm install -g fern-api
 
-      - name: Release SDKs
+      - name: Release Staging SDKs
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: fern generate --group staging --log-level debug
+      
+      - name: Generate Staging Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --group staging-docs --log-level debug
 
   fern-generate-production:
     needs: fern-check
@@ -56,3 +61,8 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: fern generate --group production --version ${{ github.ref_name }} --log-level debug
+      
+      - name: Generate Production Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --group production-docs --log-level debug

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -25,9 +25,9 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-  docs:
     docs:
-      domain: vellum-staging.docs.buildwithfern.com
+      docs:
+        domain: vellum-staging.docs.buildwithfern.com
 
   production:
     generators:

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -25,6 +25,9 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+  docs:
+    docs:
+      domain: vellum-staging.docs.buildwithfern.com
 
   production:
     generators:

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -25,9 +25,10 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+  staging-docs:
     docs:
-      docs:
-        domain: vellum-staging.docs.buildwithfern.com
+      domain: vellum-staging.docs.buildwithfern.com
+    generators: []
 
   production:
     generators:
@@ -53,8 +54,7 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-
-  docs:
+  production-docs:
     docs:
       domain: vellum.docs.buildwithfern.com
       custom-domains:


### PR DESCRIPTION
Staging docs will be published to https://vellum-staging.docs.buildwithfern.com. 

Docs will be updated in CI when you run `fern generate`. 