### PR TITLE
Proposal for adding an overrides parameter to the GenerateRequest API

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -950,6 +950,11 @@ components:
           description: Optionally include a unique identifier for each generation,
             as represented outside of Vellum. Note that this should generally be a
             list of length one.
+        overrides:
+          type: object
+          additionalProperties: {}
+          description: Optionally include parameters that are forwarded to the API call made to
+            the deployment's model
       required:
       - input_values
     GenerateResponse:


### PR DESCRIPTION
Hey 👋

Recently, I saw OpenAI's announcement on [function calling](https://openai.com/blog/function-calling-and-other-api-updates) and immediately wanted to start playing with it. As a user of Vellum though, my interaction with this new model is through _Vellum_'s API, which doesn't currently support taking in functions.

This could be a huge undertaking to support on the platform. This feature brings with it a new role, a complex api parameter that would need to convert into UI components on the dashboard, and even new properties to consider in responses. If I don't want to wait until Vellum supports this (or any future feature), I'd love to be able to send the parameters manually until it gets built.

Here's an example of how I would use this parameter: https://github.com/vargasarts/padawan.davidvargas.me/blob/f1c0edc85315c077e76030a0000033bfaf4fe8e3/api/develop.ts#L200-L216

Ideally, this would forward the `functions` parameter to OpenAI's [Create chat completion API](https://platform.openai.com/docs/api-reference/chat/create#chat/create-functions).

I understand that this can't be merged without backend changes being made first, I just find pull requests as effective mediums for communicating ideas & feature requests. Leaving as Draft to see what you guys think