### PR TITLE
Use .mdx for docs instead of .md

### DIFF
--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -2,7 +2,7 @@ navigation:
   - section: Introduction
     contents:
       - page: Getting started
-        path: ./intro.md
+        path: ./intro.mdx
   - api: API Reference
 title: Vellum | API Docs
 colors:

--- a/fern/api/docs/intro.mdx
+++ b/fern/api/docs/intro.mdx
@@ -1,5 +1,3 @@
-## Vellum API Documentation
-
 ### Welcome 👋
 
 Welcome to Vellum's API documentation! Here you'll find information about the various endpoints available to you,
@@ -10,23 +8,27 @@ via the UI that you wish you could perform via API, please let us know and we ca
 
 ### API Stability
 
-Some of the APIs documented within are undergoing active development. Use the
-<strong style="background-color:#4caf50; color:white; padding:4px; border-radius:4px">Stable</strong>
-and
-<strong style="background-color:#ffc107; color:white; padding:4px; border-radius:4px">Unstable</strong>
-tags to differentiate between those that are stable and those that are not.
+<P style={{lineHeight: "2rem"}}>
+<span>Some of the APIs documented within are undergoing active development. Use the </span>
+<strong style={{ backgroundColor: "#4caf50", color: "white", padding: 4, borderRadius: 4 }}>Stable</strong>
+<span> and </span>
+<strong style={{ backgroundColor: "#ffc107", color: "white", padding: 4, borderRadius: 4 }}>Unstable</strong>
+<span> tags to differentiate between those that are stable and those that are not.</span>
+</P>
 
 ### Base URLs
 
 Some endpoints are hosted separately from the main Vellum API and therefore have a different base url. If this is
 the case, they will say so in their description.
 
-Unless otherwise specified, all endpoints use <code>https://api.vellum.ai</code> as their base URL.
+Unless otherwise specified, all endpoints use `https://api.vellum.ai` as their base URL.
 
 ### Official API Clients:
 
 Vellum maintains official API clients for Python and Node/Typescript. We recommend using these clients to interact
 with all stable endpoints. You can find them here:
 
-- [Python](https://github.com/vellum-ai/vellum-client-python)
-- [Node/Typescript](https://github.com/vellum-ai/vellum-client-node)
+<Cards center>
+    <Card title="Python" href="https://github.com/vellum-ai/vellum-client-python" />
+    <Card title="Node/Typescript" href="https://github.com/vellum-ai/vellum-client-node" />
+</Cards>

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -54,10 +54,6 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-  dev-docs:
-    docs:
-      domain: vellum.docs.dev.buildwithfern.com
-    generators: []
   production-docs:
     docs:
       domain: vellum.docs.buildwithfern.com

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -54,6 +54,10 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+  dev-docs:
+    docs:
+      domain: vellum.docs.dev.buildwithfern.com
+    generators: []
   production-docs:
     docs:
       domain: vellum.docs.buildwithfern.com

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-  "organization": "vellum",
-  "version": "0.10.8"
+	"organization": "vellum",
+	"version": "0.11.2"
 }


### PR DESCRIPTION
Fern recently added support for mdx, which gives you access to richer components than markdown.

In this PR, I've upgraded fern to the latest version and modified your intro page to use one of our mdx components:

```mdx
<Cards center>
    <Card title="Python" href="https://github.com/vellum-ai/vellum-client-python" />
    <Card title="Node/Typescript" href="https://github.com/vellum-ai/vellum-client-node" />
</Cards>
```

<img width="1792" alt="Screenshot 2023-06-23 at 3 45 28 PM" src="https://github.com/vellum-ai/vellum-client-generator/assets/8902272/92314cc6-92a3-4531-bd71-9f7f06223762">
