### PR TITLE
upgrade fern to `0.11.6`

### DIFF
--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -7,5 +7,7 @@ navigation:
 title: Vellum | API Docs
 colors:
   accentPrimary: "#a3d3ff"
-logo: ./logo.png
+logo: 
+  path: ./logo.png
+  href: https://www.vellum.ai/
 favicon: ./favicon.ico

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
-	"organization": "vellum",
-	"version": "0.11.2"
+  "organization": "vellum",
+  "version": "0.11.6"
 }


### PR DESCRIPTION
The newest upgrade to Fern comes with a couple docs features: 
- the logo on the left on your docs will now link to the home page
- the next time you publish a docs website there will be a search bar that allows users to search