### PR TITLE
Revert content type change

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -209,7 +209,7 @@ paths:
       responses:
         '200':
           content:
-            application/x-ndjson:
+            application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowStreamEvent'
           description: ''
@@ -286,7 +286,7 @@ paths:
       responses:
         '200':
           content:
-            application/x-ndjson:
+            application/json:
               schema:
                 $ref: '#/components/schemas/GenerateStreamResponse'
           description: ''

--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -759,9 +759,6 @@ components:
     ConditionalNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/ConditionalNodeResultData'
       required:
@@ -776,9 +773,6 @@ components:
     ConstantValueChatHistoryVariable:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         value:
           type: array
           items:
@@ -790,9 +784,6 @@ components:
     ConstantValueJsonVariable:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         value:
           type: object
           additionalProperties: {}
@@ -803,9 +794,6 @@ components:
     ConstantValueStringVariable:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         value:
           type: string
           nullable: true
@@ -823,9 +811,6 @@ components:
     DeploymentNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/DeploymentNodeResultData'
       required:
@@ -1642,9 +1627,6 @@ components:
     PromptNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/PromptNodeResultData'
       required:
@@ -2033,9 +2015,6 @@ components:
     SandboxNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/SandboxNodeResultData'
       required:
@@ -2140,9 +2119,6 @@ components:
     SearchNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/SearchNodeResultData'
       required:
@@ -2405,9 +2381,6 @@ components:
     TerminalNodeResult:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/TerminalNodeResultData'
       required:
@@ -2556,9 +2529,6 @@ components:
     WorkflowExecutionNodeResultEvent:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/WorkflowNodeResultEvent'
       required:
@@ -2567,9 +2537,6 @@ components:
     WorkflowExecutionWorkflowResultEvent:
       type: object
       properties:
-        type:
-          type: string
-          readOnly: true
         data:
           $ref: '#/components/schemas/WorkflowResultEvent'
       required:


### PR DESCRIPTION
Fern does not support other content types (issue filed [here](https://github.com/fern-api/fern/issues/1923)). For now, let's change back to `application/json` even though this isn't accurate.