### PR TITLE
Revert Content Type Updates

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -209,7 +209,7 @@ paths:
       responses:
         '200':
           content:
-            application/x-ndjson:
+            application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowStreamEvent'
           description: ''
@@ -292,7 +292,7 @@ paths:
       responses:
         '200':
           content:
-            application/x-ndjson:
+            application/json:
               schema:
                 $ref: '#/components/schemas/GenerateStreamResponse'
           description: ''


### PR DESCRIPTION
Including these continues to produce a `None` return value in our python clients. Removing for now so that we can update later.