### PR TITLE
fix: update fern CLI to handle `x-ndjson` content types

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -209,7 +209,7 @@ paths:
       responses:
         '200':
           content:
-            application/json:
+            application/x-ndjson:
               schema:
                 $ref: '#/components/schemas/WorkflowStreamEvent'
           description: ''
@@ -292,7 +292,7 @@ paths:
       responses:
         '200':
           content:
-            application/json:
+            application/x-ndjson:
               schema:
                 $ref: '#/components/schemas/GenerateStreamResponse'
           description: ''

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.11.8"
+  "version": "0.11.9"
 }


### PR DESCRIPTION
Reverts content type updates and upgrades Fern CLI to `0.11.9`