### PR TITLE
Add navbar links/CTA buttons to the header

### DIFF
--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -11,3 +11,13 @@ logo:
   path: ./logo.png
   href: https://www.vellum.ai/
 favicon: ./favicon.ico
+navbar-links:
+  - type: secondary
+    text: Products
+    url: https://vellum.ai/products
+  - type: secondary
+    text: Blog
+    url: https://vellum.ai/blog
+  - type: primary
+    text: Start 14 day trial
+    url: https://app.vellum.ai/signup

--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -7,8 +7,9 @@ navigation:
 title: Vellum | API Docs
 colors:
   accentPrimary: "#a3d3ff"
-logo: 
+logo:
   path: ./logo.png
+  height: 20
   href: https://www.vellum.ai/
 favicon: ./favicon.ico
 navbar-links:

--- a/fern/api/docs/docs.yml
+++ b/fern/api/docs/docs.yml
@@ -9,7 +9,6 @@ colors:
   accentPrimary: "#a3d3ff"
 logo:
   path: ./logo.png
-  height: 20
   href: https://www.vellum.ai/
 favicon: ./favicon.ico
 navbar-links:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.11.9"
+  "version": "0.11.10"
 }


### PR DESCRIPTION
With this PR, Vellum will be able to add navbar links/CTA buttons to the header.

<img width="1456" alt="Screenshot 2023-07-28 at 12 34 20 AM" src="https://github.com/vellum-ai/vellum-client-generator/assets/36949216/2443b486-ce52-4fc7-a04d-37fe1c296fef">