### PR TITLE
Clean Up Client Endpoints

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -572,50 +572,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchErrorResponse'
           description: ''
-  /v1/set-document-metadata:
-    post:
-      operationId: set_document_metadata
-      description: |-
-        <strong style="background-color:#4caf50; color:white; padding:4px; border-radius:4px">Stable</strong>
-
-        Set the metadata for a document to be used for search filtering.
-
-        **Note:** Uses a base url of `https://documents.vellum.ai`.
-      tags:
-      - documents
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetDocumentMetadataRequestBodyRequest'
-        required: true
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetDocumentMetadataResponse'
-          description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetDocumentMetadataErrorResponse'
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetDocumentMetadataErrorResponse'
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SetDocumentMetadataErrorResponse'
-          description: ''
       servers:
         - url: https://documents.vellum.ai
           x-name: Documents
@@ -1757,8 +1713,11 @@ components:
     ProcessingFailureReasonEnum:
       enum:
       - EXCEEDED_CHARACTER_LIMIT
+      - INVALID_FILE
       type: string
-      description: '* `EXCEEDED_CHARACTER_LIMIT` - Exceeded Character Limit'
+      description: |-
+        * `EXCEEDED_CHARACTER_LIMIT` - Exceeded Character Limit
+        * `INVALID_FILE` - Invalid File
     ProcessingStateEnum:
       enum:
       - QUEUED
@@ -2415,44 +2374,6 @@ components:
       required:
       - keywords
       - semantic_similarity
-    SetDocumentMetadataErrorResponse:
-      type: object
-      properties:
-        detail:
-          type: string
-      required:
-      - detail
-    SetDocumentMetadataRequestBodyRequest:
-      type: object
-      properties:
-        document_id:
-          type: string
-          format: uuid
-          nullable: true
-          description: The ID of the document to update. Must provide either this
-            or `external_id`
-        external_id:
-          type: string
-          nullable: true
-          minLength: 1
-          description: The external ID of the document to update. Must provide either
-            this or `document_id`
-        metadata:
-          type: object
-          additionalProperties: {}
-          description: The metadata to set on the document. This will overwrite any
-            existing metadata.
-      required:
-      - metadata
-    SetDocumentMetadataResponse:
-      type: object
-      properties:
-        document_id:
-          type: string
-          format: uuid
-          description: The ID of the newly created document.
-      required:
-      - document_id
     SlimDocument:
       type: object
       properties:
@@ -2494,6 +2415,7 @@ components:
             An enum value representing why the document could not be processed. Is null unless processing_state is FAILED.
 
             * `EXCEEDED_CHARACTER_LIMIT` - Exceeded Character Limit
+            * `INVALID_FILE` - Invalid File
         status:
           allOf:
           - $ref: '#/components/schemas/SlimDocumentStatusEnum'
@@ -2809,8 +2731,11 @@ components:
     WorkflowExecutionNodeResultEvent:
       type: object
       properties:
+        execution_id:
+          type: string
         run_id:
           type: string
+          nullable: true
         external_id:
           type: string
           nullable: true
@@ -2820,13 +2745,17 @@ components:
           $ref: '#/components/schemas/WorkflowNodeResultEvent'
       required:
       - data
-      - run_id
+      - execution_id
       - type
     WorkflowExecutionWorkflowResultEvent:
       type: object
       properties:
+        execution_id:
+          type: string
         run_id:
           type: string
+          nullable: true
+          deprecated: true
         external_id:
           type: string
           nullable: true
@@ -2836,7 +2765,7 @@ components:
           $ref: '#/components/schemas/WorkflowResultEvent'
       required:
       - data
-      - run_id
+      - execution_id
       - type
     WorkflowNodeResultData:
       oneOf:


### PR DESCRIPTION
1. Remove set_document_metadata endpoint
2. Begin transition from `run_id` to `execution_id`