### PR TITLE
Upgrade the Python SDK generator to `0.3.15`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -14,7 +14,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node-staging
       - name: fernapi/fern-python-sdk
-        version: 0.3.8-rc16
+        version: 0.3.15
         # TODO(vellum): configure publish to private coordinate
         # output:
         #   location: pypi
@@ -44,7 +44,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node
       - name: fernapi/fern-python-sdk
-        version: 0.3.8-rc16
+        version: 0.3.15
         output:
           location: pypi
           package-name: vellum-ai


### PR DESCRIPTION
This upgrade has a bugfix (https://github.com/fern-api/fern-python/pull/323) that makes sure JSON parsing on streaming endpoints work.