### PR TITLE
Support 400 Response for Execute Workflow Stream API

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -248,6 +248,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkflowStreamEvent'
           description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
         '404':
           content:
             application/json:
@@ -2643,6 +2650,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChatMessage'
+          nullable: true
       required:
       - name
       - type
@@ -2659,6 +2667,7 @@ components:
         value:
           type: object
           additionalProperties: {}
+          nullable: true
       required:
       - name
       - type
@@ -2702,6 +2711,7 @@ components:
           type: string
         value:
           type: string
+          nullable: true
       required:
       - name
       - type


### PR DESCRIPTION
The Execute Workflow Stream API may respond with 400's if you pass invalid data. Now, API clients will be able to handle this case.

Additionally, we've made output types nullable in the case that you didn't specify an output value in Final Output Nodes.