### PR TITLE
:herb: Fix text styles in intro.mdx

### DIFF
--- a/fern/api/docs/intro.mdx
+++ b/fern/api/docs/intro.mdx
@@ -8,13 +8,11 @@ via the UI that you wish you could perform via API, please let us know and we ca
 
 ### API Stability
 
-<P style={{lineHeight: "2rem"}}>
-<span>Some of the APIs documented within are undergoing active development. Use the </span>
+Some of the APIs documented within are undergoing active development. Use the 
 <strong style={{ backgroundColor: "#4caf50", color: "white", padding: 4, borderRadius: 4 }}>Stable</strong>
-<span> and </span>
+and 
 <strong style={{ backgroundColor: "#ffc107", color: "white", padding: 4, borderRadius: 4 }}>Unstable</strong>
-<span> tags to differentiate between those that are stable and those that are not.</span>
-</P>
+tags to differentiate between those that are stable and those that are not.
 
 ### Base URLs
 


### PR DESCRIPTION
The `span` html tag was causing the font to render differently from the rest of the body text. 
<img width="848" alt="Screen Shot 2023-09-04 at 9 37 50 AM" src="https://github.com/vellum-ai/vellum-client-generator/assets/10870189/2f115f8f-02bb-4af2-a385-12bd016da27a">
