### PR TITLE
:herb: add `pull-request` mode

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,31 +1,4 @@
 groups:
-  staging:
-    generators:
-      - name: fernapi/fern-typescript-sdk
-        version: 0.5.18
-        # TODO(vellum): configure publish to private coordinate
-        # output:
-        #   location: npm
-        #   package-name: vellum-ai
-        #   token: ${NPM_TOKEN}
-        config:
-          namespaceExport: Vellum
-          timeoutInSeconds: infinity
-        github:
-          repository: vellum-ai/vellum-client-node-staging
-      - name: fernapi/fern-python-sdk
-        version: 0.4.4
-        # TODO(vellum): configure publish to private coordinate
-        # output:
-        #   location: pypi
-        #   package-name: vellum-ai
-        #   token: ${PYPI_TOKEN}
-        github:
-          repository: vellum-ai/vellum-client-python-staging
-        config:
-          client_class_name: Vellum
-          timeout_in_seconds: infinity
-
   production:
     generators:
       - name: fernapi/fern-typescript-sdk
@@ -39,6 +12,7 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node
+          mode: pull-request
       - name: fernapi/fern-python-sdk
         version: 0.4.4
         output:
@@ -47,6 +21,7 @@ groups:
           token: ${PYPI_TOKEN}
         github:
           repository: vellum-ai/vellum-client-python
+          mode: pull-request
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,4 +1,20 @@
 groups:
+   staging:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: 0.5.18
+        config:
+          namespaceExport: Vellum
+          timeoutInSeconds: infinity
+        github:
+          repository: vellum-ai/vellum-client-node-staging
+      - name: fernapi/fern-python-sdk
+        version: 0.4.4
+        github:
+          repository: vellum-ai/vellum-client-python-staging
+        config:
+          client_class_name: Vellum
+          timeout_in_seconds: infinity
   production:
     generators:
       - name: fernapi/fern-typescript-sdk


### PR DESCRIPTION
In this mode, anytime you update the OpenAPI spec, Fern will open a PR against the SDK repos. However, you'll have to merge and tag each SDK repo to actually trigger publishing to npm/pypi. 