### PR TITLE
:herb: upgrade fern cli + python generator to support pydantic v2

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.15.0-rc24"
+  "version": "0.15.0-rc37"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -9,7 +9,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node-staging
       - name: fernapi/fern-python-sdk
-        version: 0.4.4
+        version: 0.6.0-rc0
         github:
           repository: vellum-ai/vellum-client-python-staging
         config:
@@ -29,7 +29,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node
       - name: fernapi/fern-python-sdk
-        version: 0.4.4
+        version: 0.6.0-rc0
         output:
           location: pypi
           package-name: vellum-ai


### PR DESCRIPTION
In this upgrade, we are bumping the python generator version which includes support for generating a client that is compatible with Pydantic V2. 