### PR TITLE
🌿 Add fern-go-sdk generator

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.15.0-rc41"
+  "version": "0.15.0-rc57"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -15,6 +15,10 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+      - name: fernapi/fern-go-sdk
+        version: 0.9.0
+        github:
+          repository: vellum-ai/vellum-client-go-staging
   production:
     generators:
       - name: fernapi/fern-typescript-sdk
@@ -39,3 +43,7 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+      - name: fernapi/fern-go-sdk
+        version: 0.9.0
+        github:
+          repository: vellum-ai/vellum-client-go


### PR DESCRIPTION
This adds the `fern-go-sdk` generator for both `staging` and `production`. Note that the repositories will need to be created before `fern generate` is run.