### PR TITLE
Fix Node Client Streaming Endpoints

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.15.0-rc57"
+  "version": "0.15.0-rc74"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -22,7 +22,7 @@ groups:
   production:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 0.5.18
+        version: 0.8.6
         output:
           location: npm
           package-name: vellum-ai


### PR DESCRIPTION
Uses a new release of fern to get streaming endpoints to work as expected. Note that this is a breaking change for node clients.