### PR TITLE
Update execute prompt descriptions

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -278,7 +278,11 @@ paths:
   /v1/execute-prompt:
     post:
       operationId: execute_prompt
-      description: Executes a deployed Prompt and returns the result.
+      description: |-
+        Executes a deployed Prompt and returns the result.
+
+        Note: This endpoint temporarily does not support prompts with function calling, support is coming soon.
+        In the meantime, we recommend still using the `/generate` endpoint for prompts with funciton calling.
       tags:
       - execute-prompt
       requestBody:
@@ -326,7 +330,11 @@ paths:
   /v1/execute-prompt-stream:
     post:
       operationId: execute_prompt_stream
-      description: Executes a deployed Prompt and streams back the results.
+      description: |-
+        Executes a deployed Prompt and streams back the results.
+
+        Note: This endpoint temporarily does not support prompts with function calling, support is coming soon.
+        In the meantime, we recommend still using the `/generate-stream` endpoint for prompts with funciton calling
       tags:
       - execute-prompt-stream
       requestBody:

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -282,7 +282,7 @@ paths:
         Executes a deployed Prompt and returns the result.
 
         Note: This endpoint temporarily does not support prompts with function calling, support is coming soon.
-        In the meantime, we recommend still using the `/generate` endpoint for prompts with funciton calling.
+        In the meantime, we recommend still using the `/generate` endpoint for prompts with function calling.
       tags:
       - execute-prompt
       requestBody:
@@ -334,7 +334,7 @@ paths:
         Executes a deployed Prompt and streams back the results.
 
         Note: This endpoint temporarily does not support prompts with function calling, support is coming soon.
-        In the meantime, we recommend still using the `/generate-stream` endpoint for prompts with funciton calling
+        In the meantime, we recommend still using the `/generate-stream` endpoint for prompts with function calling
       tags:
       - execute-prompt-stream
       requestBody:


### PR DESCRIPTION
@noanflaherty is there a way to redeploy the fern site without cutting a new release? Or is that not desirable?