### PR TITLE
Integrate fern's latest manifest changes and list deployment endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,35 @@ jobs:
       - name: Check Fern API is valid
         run: fern check
 
+  fern-generate-branch:
+    needs: fern-check
+    if: github.event_name == 'push' && !contains(github.ref, 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Release Branch SDKs
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          fern generate --group branch-node --log-level debug
+          fern generate --group branch-python --log-level debug
+          fern generate --group branch-go --log-level debug
+      
+      - name: Generate Branch Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --docs --instance vellum-branch.docs.buildwithfern.com --log-level debug
+
   fern-generate-staging:
     needs: fern-check
     if: github.event_name == 'push' && contains(github.ref, 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
           fern generate --group branch-python --log-level debug
           fern generate --group branch-go --log-level debug
       
-      - name: Generate Branch Docs
+      - name: Generate Staging Docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs --instance vellum-branch.docs.buildwithfern.com --log-level debug
+        run: fern generate --docs --instance vellum-staging.docs.buildwithfern.com --log-level debug
 
   fern-generate-staging:
     needs: fern-check

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -106,6 +106,9 @@ navigation:
           - page: Getting started
             path: ./docs/content/api/intro.mdx
       - api: API Reference
+        snippets:
+          python: fern-api
+          typescript: "@fern-api/node-sdk"
 title: Vellum | Documentation
 colors:
   accentPrimary: "#C7D2FE"

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.16.16"
+  "version": "0.16.36"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -19,7 +19,7 @@ groups:
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.1
+        version: 0.9.4
         github:
           repository: vellum-ai/vellum-client-node-staging
           mode: pull-request
@@ -49,7 +49,7 @@ groups:
   staging:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.1
+        version: 0.9.4
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
@@ -89,7 +89,7 @@ groups:
   production:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.1
+        version: 0.9.4
         output:
           location: npm
           package-name: vellum-ai

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -23,15 +23,15 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node-staging
           mode: pull-request
+          license: MIT
+          keywords: ["vellum", "ai", "llm"]
+          description: "A Typescript Node Library to interact with the Vellum API"
+          authors: ["devops@vellum.ai", "fern[bot]"]
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
         location: 
           output: package.json
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Typescript Node Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
   branch-go:
     generators:
       - name: fernapi/fern-go-sdk
@@ -55,12 +55,12 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node-staging
+          license: MIT
+          keywords: ["vellum", "ai", "llm"]
+          description: "A Typescript Node Library to interact with the Vellum API"
+          authors: ["devops@vellum.ai", "fern[bot]"]
         location: 
           output: package.json
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Typescript Node Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         github:
@@ -99,12 +99,12 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node
+          license: MIT
+          keywords: ["vellum", "ai", "llm"]
+          description: "A Typescript Node Library to interact with the Vellum API"
+          authors: ["devops@vellum.ai", "fern[bot]"]
         location: 
           output: package.json
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Typescript Node Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         output:

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -9,28 +9,29 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Python Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: pypi
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Python Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: pypi
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.0
+        version: 0.9.1
         github:
           repository: vellum-ai/vellum-client-node-staging
           mode: pull-request
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
+        location: 
+          output: package.json
         license: MIT
         keywords: ["vellum", "ai", "llm"]
         description: "A Typescript Node Library to interact with the Vellum API"
         authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: package.json
   branch-go:
     generators:
       - name: fernapi/fern-go-sdk
@@ -38,27 +39,28 @@ groups:
         github:
           repository: vellum-ai/vellum-client-go-staging
           mode: pull-request
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Go Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: go.mod
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Go Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: go.mod
   staging:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.0
+        version: 0.9.1
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node-staging
+        location: 
+          output: package.json
         license: MIT
         keywords: ["vellum", "ai", "llm"]
         description: "A Typescript Node Library to interact with the Vellum API"
         authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: package.json
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         github:
@@ -66,26 +68,28 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Python Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: pypi
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Python Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go-staging
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Go Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: go.mod
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Go Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: go.mod
   production:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.9.0
+        version: 0.9.1
         output:
           location: npm
           package-name: vellum-ai
@@ -95,12 +99,12 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node
+        location: 
+          output: package.json
         license: MIT
         keywords: ["vellum", "ai", "llm"]
         description: "A Typescript Node Library to interact with the Vellum API"
         authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: package.json
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         output:
@@ -112,19 +116,21 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Python Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: pypi
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Python Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go
-        license: MIT
-        keywords: ["vellum", "ai", "llm"]
-        description: "A Go Library to interact with the Vellum API"
-        authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: go.mod
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+        # license: MIT
+        # keywords: ["vellum", "ai", "llm"]
+        # description: "A Go Library to interact with the Vellum API"
+        # authors: ["devops@vellum.ai", "fern[bot]"]
+        # location: 
+        #   output: go.mod

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -6,16 +6,17 @@ groups:
         github:
           repository: vellum-ai/vellum-client-python-staging
           mode: pull-request
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+          # license: MIT
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Python Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: pypi
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
-        # keywords: ["vellum", "ai", "llm"]
-        # description: "A Python Library to interact with the Vellum API"
-        # authors: ["devops@vellum.ai", "fern[bot]"]
-        # location: 
-        #   output: pypi
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -24,14 +25,15 @@ groups:
           repository: vellum-ai/vellum-client-node-staging
           mode: pull-request
           license: MIT
-          keywords: ["vellum", "ai", "llm"]
-          description: "A Typescript Node Library to interact with the Vellum API"
-          authors: ["devops@vellum.ai", "fern[bot]"]
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Typescript Node Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: package.json
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
-        location: 
-          output: package.json
   branch-go:
     generators:
       - name: fernapi/fern-go-sdk
@@ -41,6 +43,7 @@ groups:
           mode: pull-request
         # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
         # license: MIT
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
         # keywords: ["vellum", "ai", "llm"]
         # description: "A Go Library to interact with the Vellum API"
         # authors: ["devops@vellum.ai", "fern[bot]"]
@@ -56,31 +59,34 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node-staging
           license: MIT
-          keywords: ["vellum", "ai", "llm"]
-          description: "A Typescript Node Library to interact with the Vellum API"
-          authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: package.json
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Typescript Node Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: package.json
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         github:
           repository: vellum-ai/vellum-client-python-staging
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+          # license: MIT
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Python Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: pypi
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
-        # keywords: ["vellum", "ai", "llm"]
-        # description: "A Python Library to interact with the Vellum API"
-        # authors: ["devops@vellum.ai", "fern[bot]"]
-        # location: 
-        #   output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go-staging
         # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
         # license: MIT
+        # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
         # keywords: ["vellum", "ai", "llm"]
         # description: "A Go Library to interact with the Vellum API"
         # authors: ["devops@vellum.ai", "fern[bot]"]
@@ -100,11 +106,12 @@ groups:
         github:
           repository: vellum-ai/vellum-client-node
           license: MIT
-          keywords: ["vellum", "ai", "llm"]
-          description: "A Typescript Node Library to interact with the Vellum API"
-          authors: ["devops@vellum.ai", "fern[bot]"]
-        location: 
-          output: package.json
+          # location: 
+          #   output: package.json
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Typescript Node Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         output:
@@ -113,24 +120,26 @@ groups:
           token: ${PYPI_TOKEN}
         github:
           repository: vellum-ai/vellum-client-python
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+          # license: MIT
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Python Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: pypi
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
-        # keywords: ["vellum", "ai", "llm"]
-        # description: "A Python Library to interact with the Vellum API"
-        # authors: ["devops@vellum.ai", "fern[bot]"]
-        # location: 
-        #   output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
-        # keywords: ["vellum", "ai", "llm"]
-        # description: "A Go Library to interact with the Vellum API"
-        # authors: ["devops@vellum.ai", "fern[bot]"]
-        # location: 
-        #   output: go.mod
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
+          # license: MIT
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Go Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: go.mod

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -9,6 +9,12 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Python Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: pypi
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -19,6 +25,12 @@ groups:
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Typescript Node Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: package.json
   branch-go:
     generators:
       - name: fernapi/fern-go-sdk
@@ -26,6 +38,12 @@ groups:
         github:
           repository: vellum-ai/vellum-client-go-staging
           mode: pull-request
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Go Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: go.mod
   staging:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -35,6 +53,12 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node-staging
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Typescript Node Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: package.json
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         github:
@@ -42,10 +66,22 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Python Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go-staging
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Go Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: go.mod
   production:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -59,6 +95,12 @@ groups:
           timeoutInSeconds: infinity
         github:
           repository: vellum-ai/vellum-client-node
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Typescript Node Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: package.json
       - name: fernapi/fern-python-sdk
         version: 0.6.5
         output:
@@ -70,7 +112,19 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Python Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: pypi
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go
+        license: MIT
+        keywords: ["vellum", "ai", "llm"]
+        description: "A Go Library to interact with the Vellum API"
+        authors: ["devops@vellum.ai", "fern[bot]"]
+        location: 
+          output: go.mod

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -1046,6 +1046,54 @@ components:
       - status_code
       - status_code_output_id
       - text_output_id
+    ArrayChatMessageContent:
+      type: object
+      description: A list of chat message content items.
+      properties:
+        type:
+          type: string
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayChatMessageContentItem'
+      required:
+      - type
+      - value
+    ArrayChatMessageContentItem:
+      oneOf:
+      - $ref: '#/components/schemas/StringChatMessageContent'
+      - $ref: '#/components/schemas/FunctionCallChatMessageContent'
+      - $ref: '#/components/schemas/ImageChatMessageContent'
+      discriminator:
+        propertyName: type
+        mapping:
+          STRING: '#/components/schemas/StringChatMessageContent'
+          FUNCTION_CALL: '#/components/schemas/FunctionCallChatMessageContent'
+          IMAGE: '#/components/schemas/ImageChatMessageContent'
+    ArrayChatMessageContentItemRequest:
+      oneOf:
+      - $ref: '#/components/schemas/StringChatMessageContentRequest'
+      - $ref: '#/components/schemas/FunctionCallChatMessageContentRequest'
+      - $ref: '#/components/schemas/ImageChatMessageContentRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          STRING: '#/components/schemas/StringChatMessageContentRequest'
+          FUNCTION_CALL: '#/components/schemas/FunctionCallChatMessageContentRequest'
+          IMAGE: '#/components/schemas/ImageChatMessageContentRequest'
+    ArrayChatMessageContentRequest:
+      type: object
+      description: A list of chat message content items.
+      properties:
+        type:
+          type: string
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayChatMessageContentItemRequest'
+      required:
+      - type
+      - value
     BlockTypeEnum:
       enum:
       - CHAT_MESSAGE
@@ -1060,6 +1108,7 @@ components:
         * `FUNCTION_DEFINITION` - FUNCTION_DEFINITION
     ChatHistoryInputRequest:
       type: object
+      description: A user input representing a list of chat messages
       properties:
         name:
           type: string
@@ -1082,9 +1131,38 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/ChatMessageRole'
+        content:
+          allOf:
+          - $ref: '#/components/schemas/ChatMessageContent'
+          nullable: true
       required:
       - role
-      - text
+    ChatMessageContent:
+      oneOf:
+      - $ref: '#/components/schemas/StringChatMessageContent'
+      - $ref: '#/components/schemas/FunctionCallChatMessageContent'
+      - $ref: '#/components/schemas/ArrayChatMessageContent'
+      - $ref: '#/components/schemas/ImageChatMessageContent'
+      discriminator:
+        propertyName: type
+        mapping:
+          STRING: '#/components/schemas/StringChatMessageContent'
+          FUNCTION_CALL: '#/components/schemas/FunctionCallChatMessageContent'
+          ARRAY: '#/components/schemas/ArrayChatMessageContent'
+          IMAGE: '#/components/schemas/ImageChatMessageContent'
+    ChatMessageContentRequest:
+      oneOf:
+      - $ref: '#/components/schemas/StringChatMessageContentRequest'
+      - $ref: '#/components/schemas/FunctionCallChatMessageContentRequest'
+      - $ref: '#/components/schemas/ArrayChatMessageContentRequest'
+      - $ref: '#/components/schemas/ImageChatMessageContentRequest'
+      discriminator:
+        propertyName: type
+        mapping:
+          STRING: '#/components/schemas/StringChatMessageContentRequest'
+          FUNCTION_CALL: '#/components/schemas/FunctionCallChatMessageContentRequest'
+          ARRAY: '#/components/schemas/ArrayChatMessageContentRequest'
+          IMAGE: '#/components/schemas/ImageChatMessageContentRequest'
     ChatMessageRequest:
       type: object
       properties:
@@ -1092,9 +1170,12 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/ChatMessageRole'
+        content:
+          allOf:
+          - $ref: '#/components/schemas/ChatMessageContentRequest'
+          nullable: true
       required:
       - role
-      - text
     ChatMessageRole:
       enum:
       - SYSTEM
@@ -1264,10 +1345,9 @@ components:
         inputs:
           type: array
           items:
-            allOf:
-            - $ref: '#/components/schemas/PromptDeploymentInputRequest'
-            description: The list of inputs defined in the Prompt's deployment with
-              their corresponding values.
+            $ref: '#/components/schemas/PromptDeploymentInputRequest'
+          description: The list of inputs defined in the Prompt's deployment with
+            their corresponding values.
       required:
       - inputs
     DeploymentProviderPayloadResponse:
@@ -1645,10 +1725,9 @@ components:
         inputs:
           type: array
           items:
-            allOf:
-            - $ref: '#/components/schemas/PromptDeploymentInputRequest'
-            description: The list of inputs defined in the Prompt's deployment with
-              their corresponding values.
+            $ref: '#/components/schemas/PromptDeploymentInputRequest'
+          description: The list of inputs defined in the Prompt's deployment with
+            their corresponding values.
         prompt_deployment_id:
           type: string
           format: uuid
@@ -1709,10 +1788,9 @@ components:
         inputs:
           type: array
           items:
-            allOf:
-            - $ref: '#/components/schemas/PromptDeploymentInputRequest'
-            description: The list of inputs defined in the Prompt's deployment with
-              their corresponding values.
+            $ref: '#/components/schemas/PromptDeploymentInputRequest'
+          description: The list of inputs defined in the Prompt's deployment with
+            their corresponding values.
         prompt_deployment_id:
           type: string
           format: uuid
@@ -1904,6 +1982,64 @@ components:
         mapping:
           FULFILLED: '#/components/schemas/FulfilledFunctionCall'
           REJECTED: '#/components/schemas/RejectedFunctionCall'
+    FunctionCallChatMessageContent:
+      type: object
+      description: A function call value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/FunctionCallEnum'
+        value:
+          $ref: '#/components/schemas/FunctionCallChatMessageContentValue'
+      required:
+      - type
+      - value
+    FunctionCallChatMessageContentRequest:
+      type: object
+      description: A function call value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/FunctionCallEnum'
+        value:
+          $ref: '#/components/schemas/FunctionCallChatMessageContentValueRequest'
+      required:
+      - type
+      - value
+    FunctionCallChatMessageContentValue:
+      type: object
+      description: The final resolved function call value.
+      properties:
+        name:
+          type: string
+        arguments:
+          type: object
+          additionalProperties: {}
+        id:
+          type: string
+          nullable: true
+      required:
+      - arguments
+      - name
+    FunctionCallChatMessageContentValueRequest:
+      type: object
+      description: The final resolved function call value.
+      properties:
+        name:
+          type: string
+          minLength: 1
+        arguments:
+          type: object
+          additionalProperties: {}
+        id:
+          type: string
+          nullable: true
+          minLength: 1
+      required:
+      - arguments
+      - name
+    FunctionCallEnum:
+      type: string
+      enum:
+      - FUNCTION_CALL
     FunctionCallVariableValue:
       type: object
       properties:
@@ -2082,6 +2218,32 @@ components:
       required:
       - completion
       - completion_index
+    ImageChatMessageContent:
+      type: object
+      description: An image value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/ImageEnum'
+        value:
+          $ref: '#/components/schemas/VellumImage'
+      required:
+      - type
+      - value
+    ImageChatMessageContentRequest:
+      type: object
+      description: An image value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/ImageEnum'
+        value:
+          $ref: '#/components/schemas/VellumImageRequest'
+      required:
+      - type
+      - value
+    ImageEnum:
+      type: string
+      enum:
+      - IMAGE
     IndexingStateEnum:
       enum:
       - AWAITING_PROCESSING
@@ -2133,6 +2295,7 @@ components:
           nullable: true
     JSONInputRequest:
       type: object
+      description: A user input representing a JSON object
       properties:
         name:
           type: string
@@ -3981,8 +4144,35 @@ components:
         latency:
           type: integer
           nullable: true
+    StringChatMessageContent:
+      type: object
+      description: A string value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/StringEnum'
+        value:
+          type: string
+      required:
+      - type
+      - value
+    StringChatMessageContentRequest:
+      type: object
+      description: A string value that is used in a chat message.
+      properties:
+        type:
+          $ref: '#/components/schemas/StringEnum'
+        value:
+          type: string
+      required:
+      - type
+      - value
+    StringEnum:
+      type: string
+      enum:
+      - STRING
     StringInputRequest:
       type: object
+      description: A user input representing a string value
       properties:
         name:
           type: string
@@ -4646,6 +4836,29 @@ components:
       required:
       - code
       - message
+    VellumImage:
+      type: object
+      properties:
+        src:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+          nullable: true
+      required:
+      - src
+    VellumImageRequest:
+      type: object
+      properties:
+        src:
+          type: string
+          minLength: 1
+        metadata:
+          type: object
+          additionalProperties: {}
+          nullable: true
+      required:
+      - src
     VellumVariable:
       type: object
       properties:
@@ -4669,6 +4882,7 @@ components:
       - ERROR
       - ARRAY
       - FUNCTION_CALL
+      - IMAGE
       type: string
       description: |-
         * `STRING` - STRING
@@ -4679,6 +4893,7 @@ components:
         * `ERROR` - ERROR
         * `ARRAY` - ARRAY
         * `FUNCTION_CALL` - FUNCTION_CALL
+        * `IMAGE` - IMAGE
     WorkflowEventError:
       type: object
       properties:

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -37,6 +37,51 @@ info:
     name: MIT
     url: https://opensource.org/licenses/MIT
 paths:
+  /v1/deployments:
+    get:
+      operationId: deployments_list
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - ACTIVE
+          - ARCHIVED
+        description: |-
+          The current status of the deployment
+
+          * `ACTIVE` - Active
+          * `ARCHIVED` - Archived
+      tags:
+      - deployments
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSlimDeploymentReadList'
+          description: ''
   /v1/deployments/{id}:
     get:
       operationId: deployments_retrieve
@@ -921,6 +966,51 @@ paths:
       servers:
       - url: https://documents.vellum.ai
         x-name: Documents
+  /v1/workflow-deployments:
+    get:
+      operationId: workflow_deployments_list
+      parameters:
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - name: ordering
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - ACTIVE
+          - ARCHIVED
+        description: |-
+          The current status of the workflow deployment
+
+          * `ACTIVE` - Active
+          * `ARCHIVED` - Archived
+      tags:
+      - workflow-deployments
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedSlimWorkflowDeploymentList'
+          description: ''
 components:
   schemas:
     ApiNodeResult:
@@ -1210,12 +1300,11 @@ components:
           maxLength: 150
         status:
           allOf:
-          - $ref: '#/components/schemas/DeploymentStatus'
+          - $ref: '#/components/schemas/EntityStatus'
           description: |-
             The current status of the deployment
 
             * `ACTIVE` - Active
-            * `INACTIVE` - Inactive
             * `ARCHIVED` - Archived
         environment:
           allOf:
@@ -1226,6 +1315,13 @@ components:
             * `DEVELOPMENT` - Development
             * `STAGING` - Staging
             * `PRODUCTION` - Production
+        last_deployed_on:
+          type: string
+          format: date-time
+        input_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/VellumVariable'
         active_model_version_ids:
           type: array
           items:
@@ -1235,13 +1331,6 @@ components:
           description: Deprecated. The Prompt execution endpoints return a `prompt_version_id`
             that could be used instead.
           deprecated: true
-        last_deployed_on:
-          type: string
-          format: date-time
-        input_variables:
-          type: array
-          items:
-            $ref: '#/components/schemas/VellumVariable'
       required:
       - active_model_version_ids
       - created
@@ -1250,16 +1339,6 @@ components:
       - label
       - last_deployed_on
       - name
-    DeploymentStatus:
-      enum:
-      - ACTIVE
-      - INACTIVE
-      - ARCHIVED
-      type: string
-      description: |-
-        * `ACTIVE` - Active
-        * `INACTIVE` - Inactive
-        * `ARCHIVED` - Archived
     DocumentDocumentToDocumentIndex:
       type: object
       properties:
@@ -1303,7 +1382,7 @@ components:
           maxLength: 150
         status:
           allOf:
-          - $ref: '#/components/schemas/DocumentIndexStatus'
+          - $ref: '#/components/schemas/EntityStatus'
           description: |-
             The current status of the document index
 
@@ -1352,7 +1431,7 @@ components:
           maxLength: 150
         status:
           allOf:
-          - $ref: '#/components/schemas/DocumentIndexStatus'
+          - $ref: '#/components/schemas/EntityStatus'
           description: |-
             The current status of the document index
 
@@ -1377,14 +1456,6 @@ components:
       - indexing_config
       - label
       - name
-    DocumentIndexStatus:
-      enum:
-      - ACTIVE
-      - ARCHIVED
-      type: string
-      description: |-
-        * `ACTIVE` - Active
-        * `ARCHIVED` - Archived
     DocumentRead:
       type: object
       properties:
@@ -1503,6 +1574,14 @@ components:
       - model_version_id
       - prompt_version_id
       - text
+    EntityStatus:
+      enum:
+      - ACTIVE
+      - ARCHIVED
+      type: string
+      description: |-
+        * `ACTIVE` - Active
+        * `ARCHIVED` - Archived
     EnvironmentEnum:
       enum:
       - DEVELOPMENT
@@ -2321,6 +2400,10 @@ components:
         top_k:
           type: number
           format: double
+        custom_parameters:
+          type: object
+          additionalProperties: {}
+          nullable: true
       required:
       - frequency_penalty
       - presence_penalty
@@ -2692,6 +2775,26 @@ components:
       - text_offset
       - token
       - top_logprobs
+    PaginatedSlimDeploymentReadList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlimDeploymentRead'
     PaginatedSlimDocumentList:
       type: object
       properties:
@@ -2712,6 +2815,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SlimDocument'
+    PaginatedSlimWorkflowDeploymentList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/SlimWorkflowDeployment'
     PatchedDocumentUpdateRequest:
       type: object
       properties:
@@ -3058,6 +3181,10 @@ components:
           additionalProperties:
             type: number
             format: double
+          nullable: true
+        custom_parameters:
+          type: object
+          additionalProperties: {}
           nullable: true
       required:
       - frequency_penalty
@@ -3637,6 +3764,57 @@ components:
           minimum: 0.0
           default: 0.2
           description: The relative weight to give to keywords
+    SlimDeploymentRead:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        label:
+          type: string
+          description: A human-readable label for the deployment
+          maxLength: 150
+        name:
+          type: string
+          description: A name that uniquely identifies this deployment within its
+            workspace
+          maxLength: 150
+        status:
+          allOf:
+          - $ref: '#/components/schemas/EntityStatus'
+          description: |-
+            The current status of the deployment
+
+            * `ACTIVE` - Active
+            * `ARCHIVED` - Archived
+        environment:
+          allOf:
+          - $ref: '#/components/schemas/EnvironmentEnum'
+          description: |-
+            The environment this deployment is used in
+
+            * `DEVELOPMENT` - Development
+            * `STAGING` - Staging
+            * `PRODUCTION` - Production
+        last_deployed_on:
+          type: string
+          format: date-time
+        input_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/VellumVariable'
+      required:
+      - created
+      - id
+      - input_variables
+      - label
+      - last_deployed_on
+      - name
     SlimDocument:
       type: object
       properties:
@@ -3707,6 +3885,66 @@ components:
       - id
       - label
       - last_uploaded_at
+    SlimWorkflowDeployment:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          description: A name that uniquely identifies this workflow deployment within
+            its workspace
+          maxLength: 150
+        label:
+          type: string
+          description: A human-readable label for the workflow deployment
+          maxLength: 150
+        status:
+          allOf:
+          - $ref: '#/components/schemas/EntityStatus'
+          description: |-
+            The current status of the workflow deployment
+
+            * `ACTIVE` - Active
+            * `ARCHIVED` - Archived
+        environment:
+          allOf:
+          - $ref: '#/components/schemas/EnvironmentEnum'
+          description: |-
+            The environment this workflow deployment is used in
+
+            * `DEVELOPMENT` - Development
+            * `STAGING` - Staging
+            * `PRODUCTION` - Production
+        created:
+          type: string
+          format: date-time
+          readOnly: true
+        last_deployed_on:
+          type: string
+          format: date-time
+        input_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/VellumVariable'
+          description: The input variables this Workflow Deployment expects to receive
+            values for when it is executed.
+        output_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/VellumVariable'
+          description: The output variables this Workflow Deployment will produce
+            when it is executed.
+      required:
+      - created
+      - id
+      - input_variables
+      - label
+      - last_deployed_on
+      - name
+      - output_variables
     StreamingEnum:
       type: string
       enum:


### PR DESCRIPTION
[Context 1:](https://vellum-ai.slack.com/archives/C052UMCSFA8/p1705072329477489)
<img width="1287" alt="Screenshot 2024-01-15 at 11 59 18 AM" src="https://github.com/vellum-ai/vellum-client-generator/assets/7143571/a39328bf-6203-4e72-8738-45406cab5fc9">

[Context 2](https://github.com/vellum-ai/vellum/pull/2507), adding list deployments and workflow deployments to the vellum sdk