### PR TITLE
improvement: enable PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,6 @@ jobs:
           fern generate --group branch-node --log-level debug
           fern generate --group branch-python --log-level debug
           fern generate --group branch-go --log-level debug
-      
-      - name: Generate Staging Docs
-        env:
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs --instance vellum-staging.docs.buildwithfern.com --log-level debug
 
   fern-generate-staging:
     needs: fern-check
@@ -64,11 +59,6 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: fern generate --group staging --log-level debug
-      
-      - name: Generate Staging Docs
-        env:
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs --instance vellum-staging.docs.buildwithfern.com --log-level debug
 
   fern-generate-production:
     needs: fern-check
@@ -90,8 +80,3 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: fern generate --group production --version ${{ github.ref_name }} --log-level debug
-      
-      - name: Generate Production Docs
-        env:
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs --instance vellum.docs.buildwithfern.com --log-level debug

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,0 +1,33 @@
+name: preview-docs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Generate preview URL
+        id: generate-docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          OUTPUT=$(fern generate --docs --preview 2>&1) || true
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          echo "Preview URL: $URL"
+          echo "🌿 Preview your docs: $URL" > preview_url.txt
+
+      - name: Comment URL in PR
+        uses: thollander/actions-comment-pull-request@v2.4.3
+        with:
+          filePath: preview_url.txt

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,21 @@
+name: publish-docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Publish Docs
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: fern generate --docs --log-level debug

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,5 +1,4 @@
 instances:
-  - url: vellum-staging.docs.buildwithfern.com
   - url: vellum.docs.buildwithfern.com
     custom-domain: docs.vellum.ai
 


### PR DESCRIPTION
This PR
* Removes the staging URL
* Adds PR previews on `pull-request` as a GitHub Action
* Adds publishing on `push` as a GitHub Action