### PR TITLE
Point to Correct Packages for Snippets

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -111,7 +111,7 @@ navigation:
       - api: API Reference
         snippets:
           python: vellum-ai
-          typescript: "vellum-ai"
+          typescript: vellum-ai
   - tab: change-log
     layout:
       - section: "2024"

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -110,8 +110,8 @@ navigation:
             path: ./docs/content/api/intro.mdx
       - api: API Reference
         snippets:
-          python: fern-api
-          typescript: "@fern-api/node-sdk"
+          python: vellum-ai
+          typescript: "vellum-ai"
   - tab: change-log
     layout:
       - section: "2024"


### PR DESCRIPTION
In order to show code examples, we need to point to our packages, not fern's

Context: https://vellum-ai.slack.com/archives/C052UMCSFA8/p1707189488755649?thread_ts=1702866032.359609&cid=C052UMCSFA8

Note that this works for python, but we won't see node examples until we've cut a new release.