### PR TITLE
[SC-1039] Manually Document Upload Document API Fields

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -965,10 +965,17 @@ paths:
   /v1/upload-document:
     post:
       operationId: documents_upload
-      description: |-
-        Upload a document to be indexed and used for search.
+      description: |2
+                Upload a document to be indexed and used for search.
 
-        **Note:** Uses a base url of `https://documents.vellum.ai`.
+                **Note:** Uses a base url of `https://documents.vellum.ai`.
+
+                This is a multipart/form-data request. The `contents` field should be a file upload. It also expects a JSON        body with the following fields:
+                - `add_to_index_names: Optional[List[str]]` - Optionally include the names of all indexes that you'd like this            document to be included in
+                - `external_id: Optional[str]` - Optionally include an external ID for this document. This is useful if you            want to re-upload the same document later when its contents change and would like it to be re-indexed.
+                - `label: str` - A human-friendly name for this document. Typically the filename.
+                - `keywords: Optional[List[str]]` - Optionally include a list of keywords that'll be associated with this            document. Used when performing keyword searches.
+                - `metadata: Optional[Dict[str, Any]]` - A stringified JSON object containing any metadata associated with the            document that you'd like to filter upon later.
       tags:
       - documents
       requestBody:


### PR DESCRIPTION
Fern doesn't yet support documentation of JSON fields for multi-part form upload APIs (see issues [here](https://github.com/fern-api/fern/issues/2575)). Because of this, our upload_document API has very poor documentation in our API Docs.

As a workaround, I'm going to manually document the fields so that they show up in the API description.

## Before
<img width="1728" alt="2024-02-05_20-38-25" src="https://github.com/vellum-ai/vellum-client-generator/assets/14092604/cd24f69f-0449-4cac-b981-f1de30649612">

## After
<img width="1728" alt="2024-02-05_20-38-08" src="https://github.com/vellum-ai/vellum-client-generator/assets/14092604/09568e3f-390a-44b8-a950-f5708ef9d4fb">

### Note
Once this is approved and merged, I'll still need to update `openapi.yml` in the `vellum-client-generator` repo.