### PR TITLE
Update Spec Following Recent API / Docs Changes

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -66,11 +66,7 @@ paths:
           enum:
           - ACTIVE
           - ARCHIVED
-        description: |-
-          The current status of the deployment
-
-          * `ACTIVE` - Active
-          * `ARCHIVED` - Archived
+        description: The current status of the deployment
       tags:
       - deployments
       security:
@@ -727,8 +723,6 @@ paths:
                   - key: var_2
                     value: Why hello, there!
                     type: TEXT
-                  metric_input_params:
-                    params: {}
                 summary: Basic Example
                 description: This example shows how to specify a scenario with two
                   variables, var_1 and var_2.
@@ -744,8 +738,6 @@ paths:
                       text: What's your favorite color?
                     - role: ASSISTANT
                       text: AI's don't have a favorite color.... Yet.
-                  metric_input_params:
-                    params: {}
                 summary: Chat History Example
                 description: This example shows how to specify a chat history for
                   the special $chat_history variable.
@@ -965,10 +957,17 @@ paths:
   /v1/upload-document:
     post:
       operationId: documents_upload
-      description: |-
+      description: |
         Upload a document to be indexed and used for search.
 
         **Note:** Uses a base url of `https://documents.vellum.ai`.
+
+        This is a multipart/form-data request. The `contents` field should be a file upload. It also expects a JSON body with the following fields:
+        - `add_to_index_names: list[str]` - Optionally include the names of all indexes that you'd like this document to be included in
+        - `external_id: str | None` - Optionally include an external ID for this document. This is useful if you want to re-upload the same document later when its contents change and would like it to be re-indexed.
+        - `label: str` - A human-friendly name for this document. Typically the filename.
+        - `keywords: list[str] | None` - Optionally include a list of keywords that'll be associated with this document. Used when performing keyword searches.
+        - `metadata: dict[str, Any]` - A stringified JSON object containing any metadata associated with the document that you'd like to filter upon later.
       tags:
       - documents
       requestBody:
@@ -1766,22 +1765,6 @@ components:
       required:
       - type
       - value
-    EvaluationParams:
-      type: object
-      properties:
-        target:
-          type: string
-          nullable: true
-          description: The target value to compare the LLM output against. Typically
-            what you expect or desire the LLM output to be.
-    EvaluationParamsRequest:
-      type: object
-      properties:
-        target:
-          type: string
-          nullable: true
-          description: The target value to compare the LLM output against. Typically
-            what you expect or desire the LLM output to be.
     ExecutePromptApiErrorResponse:
       type: object
       properties:
@@ -3526,6 +3509,7 @@ components:
           format: double
         top_k:
           type: integer
+          nullable: true
         frequency_penalty:
           type: number
           format: double
@@ -3819,20 +3803,6 @@ components:
           allOf:
           - $ref: '#/components/schemas/FinishReasonEnum'
           nullable: true
-    SandboxMetricInputParams:
-      type: object
-      properties:
-        params:
-          allOf:
-          - $ref: '#/components/schemas/EvaluationParams'
-          nullable: true
-    SandboxMetricInputParamsRequest:
-      type: object
-      properties:
-        params:
-          allOf:
-          - $ref: '#/components/schemas/EvaluationParamsRequest'
-          nullable: true
     SandboxScenario:
       type: object
       properties:
@@ -3847,12 +3817,9 @@ components:
         id:
           type: string
           description: The id of the scenario
-        metric_input_params:
-          $ref: '#/components/schemas/SandboxMetricInputParams'
       required:
       - id
       - inputs
-      - metric_input_params
     ScenarioInput:
       type: object
       properties:
@@ -4957,10 +4924,12 @@ components:
           description: Optionally include an external ID for this document. This is
             useful if you want to re-upload the same document later when its contents
             change and would like it to be re-indexed.
+          maxLength: 1000
         label:
           type: string
           minLength: 1
           description: A human-friendly name for this document. Typically the filename.
+          maxLength: 1000
         contents:
           type: string
           format: binary
@@ -5014,8 +4983,6 @@ components:
           minLength: 1
           description: The id of the scenario to update. If none is provided, an id
             will be generated and a new scenario will be appended.
-        metric_input_params:
-          $ref: '#/components/schemas/SandboxMetricInputParamsRequest'
       required:
       - inputs
     UpsertTestSuiteTestCaseRequest:


### PR DESCRIPTION
This PR includes a subset of the diff between `schema_api_client_v1.yaml` in the `vellum` repo and `openai.yml` in this repo.

The changes I'm moving over include:
1. Documentation changes for our `upload_document` endpoint; and
2. Simplification of our `upsert_scenario` API, which no longer supports passing quantitative eval data.

I opted to not include some of the other diff in there that I'm less familiar with.