### PR TITLE
MIT License for python/go, split out pr.yaml, node snippet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   fern-check:
@@ -14,32 +17,6 @@ jobs:
 
       - name: Check Fern API is valid
         run: fern check
-
-  fern-generate-branch:
-    needs: fern-check
-    if: github.event_name == 'push' && !contains(github.ref, 'refs/heads/main')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-
-      - name: Download Fern
-        run: npm install -g fern-api
-
-      - name: Release Branch SDKs
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          RUBYGEM_API_KEY: ${{ secrets.RUBYGEM_API_KEY }}
-        run: |
-          fern generate --group branch-node --log-level debug
-          fern generate --group branch-python --log-level debug
-          fern generate --group branch-go --log-level debug
-          fern generate --group branch-ruby --log-level debug
 
   fern-generate-staging:
     needs: fern-check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'fern/openapi/openapi.yml'
+      - 'fern/generators.yml'
 
 jobs:
   fern-check:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: ci
+
+on:
+  pull_request:
+    paths:
+      - 'fern/openapi/openapi.yml'
+
+jobs:
+  fern-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Fern
+        run: npm install -g fern-api
+
+      - name: Check Fern API is valid
+        run: fern check
+
+  fern-generate-branch:
+    needs: fern-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Release Branch SDKs
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          RUBYGEM_API_KEY: ${{ secrets.RUBYGEM_API_KEY }}
+        run: |
+          fern generate --group branch-node --log-level debug
+          fern generate --group branch-python --log-level debug
+          fern generate --group branch-go --log-level debug
+          fern generate --group branch-ruby --log-level debug

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -111,7 +111,7 @@ navigation:
       - api: API Reference
         snippets:
           python: vellum-ai
-          typescript: vellum-ai
+          typescript: "vellum-ai"
   - tab: change-log
     layout:
       - section: "2024"

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -6,8 +6,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-python-staging
           mode: pull-request
-          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-          # license: MIT
+          license: MIT
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Python Library to interact with the Vellum API"
@@ -41,8 +40,7 @@ groups:
         github:
           repository: vellum-ai/vellum-client-go-staging
           mode: pull-request
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
+          license: MIT
         # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
         # keywords: ["vellum", "ai", "llm"]
         # description: "A Go Library to interact with the Vellum API"
@@ -81,8 +79,7 @@ groups:
         version: 0.6.5
         github:
           repository: vellum-ai/vellum-client-python-staging
-          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-          # license: MIT
+          license: MIT
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Python Library to interact with the Vellum API"
@@ -96,14 +93,13 @@ groups:
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go-staging
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-        # license: MIT
-        # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
-        # keywords: ["vellum", "ai", "llm"]
-        # description: "A Go Library to interact with the Vellum API"
-        # authors: ["devops@vellum.ai", "fern[bot]"]
-        # location: 
-        #   output: go.mod
+          license: MIT
+          # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
+          # keywords: ["vellum", "ai", "llm"]
+          # description: "A Go Library to interact with the Vellum API"
+          # authors: ["devops@vellum.ai", "fern[bot]"]
+          # location: 
+          #   output: go.mod
       - name: fernapi/fern-ruby-sdk
         version: 0.0.4-1-2059079
         output:
@@ -141,8 +137,7 @@ groups:
           token: ${PYPI_TOKEN}
         github:
           repository: vellum-ai/vellum-client-python
-          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-          # license: MIT
+          license: MIT
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Python Library to interact with the Vellum API"
@@ -156,8 +151,7 @@ groups:
         version: 0.9.0
         github:
           repository: vellum-ai/vellum-client-go
-          # Blocked on Fern - https://app.shortcut.com/vellum/story/1835
-          # license: MIT
+          license: MIT
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Go Library to interact with the Vellum API"

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -56,6 +56,7 @@ groups:
           package-name: vellum_ai
         github:
           repository: vellum-ai/vellum-client-ruby-staging
+          license: MIT
           mode: pull-request
         config:
           clientClassName: Vellum
@@ -107,6 +108,7 @@ groups:
           package-name: vellum_ai
         github:
           repository: vellum-ai/vellum-client-ruby-staging
+          license: MIT
         config:
           clientClassName: Vellum
   production:
@@ -166,5 +168,6 @@ groups:
           api-key: ${RUBYGEM_API_KEY}
         github:
           repository: vellum-ai/vellum-client-ruby
+          license: MIT
         config:
           clientClassName: Vellum


### PR DESCRIPTION
This PR does three things:
- Add the MIT license field for the python/go clients
- Split out pr.yaml from ci.yaml so that it only runs on PRs and only when sdk generating files are touched
- Attempts to fix the node snippet