### PR TITLE
Fix the listener on the ci yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 
-on:
-  push:
-    branches:
-      - main
+on: [push]
 
 jobs:
   fern-check:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: ci
+name: pr
 
 on:
   pull_request:


### PR DESCRIPTION
Got alittle too cute on the `ci.yaml` and the action didn't run for production. Reverting it back to how it was and recutting the release (0.3.2)