### PR TITLE
Upgrade fern to `0.17.2`

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.16.43"
+  "version": "0.17.2"
 }


### PR DESCRIPTION
There are several improvements for default example generation.