### PR TITLE
:herb: upgrade Ruby generator to support future versions of the Fern CLI

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -50,7 +50,7 @@ groups:
   branch-ruby:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.0.4-1-2059079
+        version: 0.1.1
         output:
           location: rubygems
           package-name: vellum_ai
@@ -161,7 +161,7 @@ groups:
           # location: 
           #   output: go.mod
       - name: fernapi/fern-ruby-sdk
-        version: 0.0.4-1-2059079
+        version: 0.1.1
         output:
           location: rubygems
           package-name: vellum_ai


### PR DESCRIPTION
This version fixes a hard dependency the Ruby generator had on a past version of the Fern CLI