### PR TITLE
Fix Supported File Types in Document Upload

### DIFF
--- a/fern/docs/content/help/documents/uploading-documents.mdx
+++ b/fern/docs/content/help/documents/uploading-documents.mdx
@@ -30,9 +30,10 @@ initially populated with the name of the file that you upload.
 In addition to sending plain strings via API, Vellum also supports uploading files of the following types:
 - .txt
 - .pdf
+- .doc
 - .docx
 - .png
-- .xlsx
+- .csv
 
 For all but .txt files, we will apply an [OCR](https://en.wikipedia.org/wiki/Optical_character_recognition) process to convert the file to a text representation. If you need another file type, please reach out!
 


### PR DESCRIPTION
This corrects the supported file types that we allow for document upload, as defined here: https://github.com/vellum-ai/vellum/blob/0a1eb0e8996874c9b13d4834e0f259f1feac78f3/django/app/core/documents/text_extractors/utils.py#L9