### PR TITLE
jack/add-inline-editing-to-changelog

### DIFF
--- a/fern/docs/content/change-log/2024-03.mdx
+++ b/fern/docs/content/change-log/2024-03.mdx
@@ -2,6 +2,18 @@
 title: Changelog | March, 2024
 ---
 
+## Inline Editing for Evaluations
+
+_March 6th, 2024_
+
+You can now edit test cases directly from the "Evaluations" tab in Workflows and Prompts!
+
+The new editing interface makes it easier than ever to make changes to test cases with long variable values, allows you to edit Chat History values with the same drag-and-drop editor you use elsewhere in the app, and adds support for formatted editing of JSON.
+
+We're continuing to add support for more variable types and will soon be applying this new edit flow to other tables through the app.
+
+![Inline Editing Release Demo](https://www.loom.com/share/03d5457e8cf2478292bd234584993705?sid=3a789c45-f4e7-4d4c-8943-612693a8309f)
+
 ## Expand Scenario in Prompt Sandbox
 
 _March 6th, 2024_


### PR DESCRIPTION
adds inline editing update notes and loom to march changelog

loom from the update here: https://www.loom.com/share/03d5457e8cf2478292bd234584993705?sid=3a789c45-f4e7-4d4c-8943-612693a8309f