### PR TITLE
(chore): Upgrade Fern CLI from 0.18.0 to 0.19.7

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.18.0"
+  "version": "0.19.7"
 }


### PR DESCRIPTION
Upgrade [Fern CLI](https://github.com/fern-api/fern) from 0.18.0 to [0.19.7](https://github.com/fern-api/fern/releases/tag/0.19.7)

---

We're making improvements to how Fern Docs handles rendering endpoints that support multipart form. In this upgrade, you should begin to see the multipart form in both your API reference, as well as in your API Playground (see screenshots below).

However, this upgrade is missing descriptions and will be addressed in a future version of the Fern CLI. More to follow!

<img width="537" alt="Screenshot 2024-03-13 at 11 35 18 AM" src="https://github.com/vellum-ai/vellum-client-generator/assets/693032/01f5e6f7-0f66-47fe-a80c-c947ebc01cb4">

<img width="1215" alt="Screenshot 2024-03-13 at 11 36 35 AM" src="https://github.com/vellum-ai/vellum-client-generator/assets/693032/7d0ad001-d684-408c-a8e7-c731ac53b2c5">
