### PR TITLE
Remove extra deps from python

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -16,8 +16,9 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-          extraDependencies: 
-            cdktf: '^0.20.5'
+          # Blocked on Fern
+          # extraDependencies: 
+          #   cdktf: '^0.20.5'
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -96,8 +97,9 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-          extraDependencies: 
-            cdktf: '^0.20.5'
+          # Blocked on Fern
+          # extraDependencies: 
+          #   cdktf: '^0.20.5'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
@@ -159,8 +161,9 @@ groups:
         config:
           client_class_name: Vellum
           timeout_in_seconds: infinity
-          extraDependencies: 
-            cdktf: '^0.20.5'
+          # Blocked on Fern
+          # extraDependencies: 
+          #   cdktf: '^0.20.5'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:


### PR DESCRIPTION
I was led astray: https://github.com/vellum-ai/vellum-client-generator/actions/runs/8562349643/job/23465434477#step:5:1946

The implication here is that no cdktf in python until fern supports (should be good for node). Merging to unblock code gen