### PR TITLE
pytest httpx instead of requests_mock

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -19,7 +19,7 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            requests_mock: '^1.11.0'
+            pytest_httpx: '^0.30.0'
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -104,7 +104,7 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            requests_mock: '^1.11.0'
+            pytest_httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
@@ -171,7 +171,7 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            requests_mock: '^1.11.0'
+            pytest_httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:


### PR DESCRIPTION
I got the request library that fern uses wrong