### PR TITLE
Release Document Retrieve Endpoint

### DIFF
--- a/fern/docs/content/change-log/2024-04.mdx
+++ b/fern/docs/content/change-log/2024-04.mdx
@@ -2,6 +2,14 @@
 title: Changelog | April, 2024
 ---
 
+## Function Call Input in Test Cases
+
+_April 23rd, 2024_
+
+Workflows support Function Call values as a valid output type. Because these function calls often come from models, it is valuable to have evaluations on these workflows that ensure that the function call output is what we expect. Test suites in Vellum now support specifying test case input and evaluation values.
+
+![Test Case Function Call](https://storage.googleapis.com/vellum-public/help-docs/function-call-test-cases.png)
+
 ## Support for Additional Models
 
 _April 19th, 2024_

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -19,7 +19,8 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            pytest-httpx: '^0.30.0'
+            # Blocked on Fern - https://app.shortcut.com/vellum/story/2709
+            # pytest-httpx: '^0.30.0'
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
@@ -104,7 +105,8 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            pytest-httpx: '^0.30.0'
+            # Blocked on Fern - https://app.shortcut.com/vellum/story/2709
+            # pytest-httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:
@@ -171,7 +173,8 @@ groups:
           extra_dependencies: 
             cdktf: '^0.20.5'
             publication: '0.0.3'
-            pytest-httpx: '^0.30.0'
+            # Blocked on Fern - https://app.shortcut.com/vellum/story/2709
+            # pytest-httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
         version: 0.9.0
         github:


### PR DESCRIPTION
- Releases Document Retrieve in our SDK
- Changelog item for function calling inputs
- Commenting out `pytest-httpx` until Fern gives us better visibility into the failure or just generates it themselves