### PR TITLE
Upgrade fern python generator version

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -2,7 +2,7 @@ groups:
   branch-python:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 0.13.4
+        version: 1.4.0-rc3
         github:
           repository: vellum-ai/vellum-client-python-staging
           mode: pull-request


### PR DESCRIPTION
Changelog: https://github.com/fern-api/fern/blob/main/generators/python/sdk/CHANGELOG.md

Note there are breaking changes.

My strategy will be to see what the diff looks like in https://github.com/vellum-ai/vellum-client-python-staging and if not too bad, then roll with it. If it looks spooky, I'll either follow their instructions to avoid the breaking changes, or just bite the bullet and cut a 0.5.0 release.