### PR TITLE
Expose Prompt Actuals `metadata` in API Clients

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -5622,6 +5622,11 @@ components:
           nullable: true
           description: Optionally provide the timestamp representing when this feedback
             was collected. Used for reporting purposes.
+        metadata:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          description: Optionally provide additional metadata about the feedback submission.
     SubmitCompletionActualsErrorResponse:
       type: object
       properties:


### PR DESCRIPTION
Now that we have API support, we can expose it in our API clients.

I plan on cutting  a new release once this is merged.