### PR TITLE
Add API Docs Page on Authentication

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -110,10 +110,13 @@ navigation:
             slug: hmac-authentication
   - tab: api
     layout:
-      - section: Introduction
+      - section: Overview
+        slug: introduction
         contents:
           - page: Getting started
             path: ./docs/content/api/intro.mdx
+          - page: Authentication
+            path: ./docs/content/api/authentication.mdx
       - api: API Reference
         snippets:
           python: vellum-ai

--- a/fern/docs/content/api/authentication.mdx
+++ b/fern/docs/content/api/authentication.mdx
@@ -1,0 +1,19 @@
+---
+title: Authentication
+description: Learn how to authenticate with the Vellum API using API tokens.
+---
+
+## Generating API Keys
+
+The Vellum API uses API keys to authenticate requests. You can view and manage your API keys in the Vellum [here](https://app.vellum.ai/api-keys).
+
+
+## Authentication
+Authentication is performed using headers. You should include your API key as the value associated with the `X_API_KEY` header in your requests.
+
+Note that all API requests must be made over HTTPS. Calls made over plain HTTP will fail. API requests without authentication will also fail.
+
+
+## API Key Best Practices
+
+The API keys you generate should be treated like passwords. Do not share your API keys in publicly accessible areas such as GitHub, client-side code, etc.

--- a/fern/docs/content/api/intro.mdx
+++ b/fern/docs/content/api/intro.mdx
@@ -1,5 +1,5 @@
 ---
-title: Welcome to Vellum – The AI product development platform
+title: Welcome to Vellum
 description: Dive into Vellum's API docs for endpoint details, parameters, and responses. Use our official Python, Node, or Go clients for stable interaction.
 ---
 
@@ -7,7 +7,7 @@ Welcome to Vellum's API documentation! Here you'll find information about the va
 as well as the parameters and responses that they accept and return.
 
 We will be exposing more and more of our APIs over time as they stabilize. If there is some action you can perform
-via the UI that you wish you could perform via API, please let us know and we can expose it here in an unstable state.
+via the UI that you wish you could perform via API, please let us know and we can expose the relevant API here.
 
 ### API Stability
 


### PR DESCRIPTION
This adds a basic page to our API docs on Authentication. 

I took inspiration from Stripe here: https://docs.stripe.com/api/authentication