### PR TITLE
Bump ts generator to 0.29.0

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.31.17"
+  "version": "0.31.21"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vellum",
-  "version": "0.31.21"
+  "version": "0.31.22"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -25,7 +25,7 @@ groups:
   branch-node:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.23.0
+        version: 0.29.0
         github:
           repository: vellum-ai/vellum-client-node-staging
           mode: pull-request
@@ -73,7 +73,7 @@ groups:
   staging:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.23.0
+        version: 0.29.0
         config:
           namespaceExport: Vellum
           timeoutInSeconds: infinity
@@ -134,7 +134,7 @@ groups:
   production:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.23.0
+        version: 0.29.0
         output:
           location: npm
           package-name: vellum-ai


### PR DESCRIPTION
[Context:](https://vellum-ai.slack.com/archives/C052UMCSFA8/p1720633907704129?thread_ts=1720483773.621559&cid=C052UMCSFA8)
![Screenshot 2024-07-10 at 2 00 35 PM](https://github.com/vellum-ai/vellum-client-generator/assets/7143571/12f767f4-0e12-4329-b6f4-2af977b195d3)
