### PR TITLE
Introduce New `add_document` API

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -293,6 +293,8 @@ navigation:
               contents:
                 - endpoint: POST https://predict.vellum.ai/v1/search
                   title: Search
+                - endpoint: POST https://api.vellum.ai/v1/document-indexes/{id}/documents/{document_id}
+                  title: Add Document
                 - endpoint: DELETE https://api.vellum.ai/v1/document-indexes/{id}/documents/{document_id}
                   title: Remove Document
                 - endpoint: POST https://api.vellum.ai/v1/document-indexes

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -1026,7 +1026,7 @@ paths:
                   id: 50c55d1d-4c37-4c83-afc1-9d895f286320
                   label: Scenario 2
                   inputs:
-                  - name: $chat_history
+                  - name: chat_history
                     type: CHAT_HISTORY
                     value:
                     - role: USER
@@ -1034,8 +1034,8 @@ paths:
                     - role: ASSISTANT
                       text: AI's don't have a favorite color.... Yet.
                 summary: Chat History Example
-                description: This example shows how to specify a chat history for
-                  the special $chat_history variable.
+                description: This example shows how to specify a value for chat history
+                  input variables.
         required: true
       security:
       - apiKeyAuth: []

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -441,6 +441,33 @@ paths:
           description: No response body
       x-fern-availability: beta
   /v1/document-indexes/{id}/documents/{document_id}:
+    post:
+      operationId: add_document
+      description: Adds a previously uploaded Document to the specified Document Index.
+      parameters:
+      - in: path
+        name: document_id
+        schema:
+          type: string
+        description: Either the Vellum-generated ID or the originally supplied external_id
+          that uniquely identifies the Document you'd like to add.
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        description: Either the Vellum-generated ID or the originally specified name
+          that uniquely identifies the Document Index to which you'd like to add the
+          Document.
+        required: true
+      tags:
+      - document-indexes
+      security:
+      - apiKeyAuth: []
+      responses:
+        '204':
+          description: No response body
+      x-fern-availability: beta
     delete:
       operationId: remove_document
       description: Removes a Document from a Document Index without deleting the Document


### PR DESCRIPTION
This introduces official support for our new `add_document` API, which allows for adding an existing Document to another Document Index programmatically.