### PR TITLE
Add `$chat_history` and Deployed Prompt Variant Display to Changelog

### DIFF
--- a/fern/docs/content/change-log/2024-07.mdx
+++ b/fern/docs/content/change-log/2024-07.mdx
@@ -2,6 +2,29 @@
 title: Changelog | July, 2024
 ---
 
+## Deployed Prompt Variant Display
+
+_July 19th, 2024_
+
+When on the Prompt Deployment Overview page, you can now see the name of the Prompt Variant that's been deployed.
+This is useful if your Prompt Sandbox has multiple Prompt Variants that you were comparing against one another
+and you're not sure which one is currently deployed.
+
+![Deployed Prompt Variant Display](https://storage.cloud.google.com/vellum-public/help-docs/changelogs/2024-07/deployed-prompt-variant-display.png)
+
+## Improvements to Prompt Chat History Variables
+
+_July 18th, 2024_
+
+It used to be that Prompts that accepted a dynamic Chat History required an input variable whose name was specifically `$chat_history`.
+This nomenclature caused frequent confusion and was a bit cumbersome to work with.
+
+Now, you can name Chat History input variables whatever you want and even rename them after-the-fact. As part of this,
+we've also centralized input variable definitions so that whether you want to create a String variable or a Chat History variable,
+you can do so via the "Add" button in the "Input Variables" section of the Prompt Editor.
+
+![Add Prompt Input Variable Button](https://storage.cloud.google.com/vellum-public/help-docs/changelogs/2024-07/add-prompt-input-variable-button.png)
+
 ## Copyable Text to Clipboard
 
 _July 18th, 2024_


### PR DESCRIPTION
Adds two items to our changelog.
1. Improvements to Prompt Chat History Input Variables; and
2. Deployed Prompt Variant Display

<img width="728" alt="2024-07-19_12-22-30" src="https://github.com/user-attachments/assets/4a5def26-bb38-4aa2-9570-c8d6ee2935eb">

<img width="745" alt="2024-07-19_12-22-35" src="https://github.com/user-attachments/assets/1e231f89-5e9c-44f4-bdf0-fa985695cf11">

