### PR TITLE
[Changelog] Expand Meta in Provider Payload API

### DIFF
--- a/fern/docs/content/change-log/2024-07.mdx
+++ b/fern/docs/content/change-log/2024-07.mdx
@@ -2,6 +2,17 @@
 title: Changelog | July, 2024
 ---
 
+## Expandable Meta Params in Retrieve Provider Payload Endpoint
+
+_July 26th, 2024_
+
+For a while now we've had [an API](/api-reference/prompts/retrieve-provider-payload) for compiling a Prompt and retrieving the exact payload that Vellum would send
+to a model provider on your behalf. We now support a new parameter in this API – `expand_meta`. With `expand_meta`,
+you can opt-in to return additional metadata relating to the compiled prompt payload. Learn more about which
+fields are expandable in our [API docs here](/api-reference/prompts/retrieve-provider-payload#request.body.expand_meta).
+
+This new field is available in our SDKs starting v0.7.3.
+
 ## Prompt Node Usage in Workflows
 
 _July 25th, 2024_

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -181,6 +181,8 @@ paths:
         to the provider yourself. Note that no guarantees are made on the format of this API's response schema, other than
         that it will be a valid payload for the configured model provider. It's not recommended that you try to parse or
         derive meaning from the response body and instead, should simply pass it directly to the model provider as is.
+
+        We encourage you to seek advise from Vellum Support before integrating with this API for production use.
       tags:
       - deployments
       requestBody:
@@ -222,6 +224,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ExecutePromptApiErrorResponse'
           description: ''
+      x-fern-availability: beta
   /v1/document-indexes:
     get:
       operationId: document_indexes_list

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -172,6 +172,15 @@ paths:
   /v1/deployments/provider-payload:
     post:
       operationId: retrieve_provider_payload
+      description: |
+        Given a set of input variable values, compile the exact payload that Vellum would send to the configured model provider
+        for execution if the execute-prompt endpoint had been invoked. Note that this endpoint does not actually execute the
+        prompt or make an API call to the model provider.
+
+        This endpoint is useful if you don't want to proxy LLM provider requests through Vellum and prefer to send them directly
+        to the provider yourself. Note that no guarantees are made on the format of this API's response schema, other than
+        that it will be a valid payload for the configured model provider. It's not recommended that you try to parse or
+        derive meaning from the response body and instead, should simply pass it directly to the model provider as is.
       tags:
       - deployments
       requestBody:


### PR DESCRIPTION
Adds our new expandable meta fields to our provider payload api. Also updates the docs for that endpoint itself.