### PR TITLE
Upgrade Go Fern Generator

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -58,11 +58,13 @@ groups:
       - deprecated
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.9.0
+        version: 0.23.0
         github:
           repository: vellum-ai/vellum-client-go-staging
           mode: pull-request
           license: MIT
+        config:
+          alwaysSendRequiredProperties: true
         # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
         # keywords: ["vellum", "ai", "llm"]
         # description: "A Go Library to interact with the Vellum API"
@@ -127,10 +129,12 @@ groups:
             # Blocked on Fern - https://app.shortcut.com/vellum/story/2709
             # pytest-httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
-        version: 0.9.0
+        version: 0.23.0
         github:
           repository: vellum-ai/vellum-client-go-staging
           license: MIT
+        config:
+          alwaysSendRequiredProperties: true
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Go Library to interact with the Vellum API"
@@ -200,10 +204,12 @@ groups:
             # Blocked on Fern - https://app.shortcut.com/vellum/story/2709
             # pytest-httpx: '^0.30.0'
       - name: fernapi/fern-go-sdk
-        version: 0.9.0
+        version: 0.23.0
         github:
           repository: vellum-ai/vellum-client-go
           license: MIT
+        config:
+          alwaysSendRequiredProperties: true
           # Blocked on Fern - https://app.shortcut.com/vellum/story/1865
           # keywords: ["vellum", "ai", "llm"]
           # description: "A Go Library to interact with the Vellum API"


### PR DESCRIPTION
This upgrades our Go generator to the latest version so that required vs optional fields are properly handled.

For context, see here: https://vellum-ai.slack.com/archives/C052UMCSFA8/p1723067503190829

I'll spot check our staging repo to determine whether there are any breaking changes with this and if not, go ahead and create a new release.