### PR TITLE
New "workflows examples" section

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -158,6 +158,9 @@ navigation:
           - page: Function Calling with Chat Models
             path: ./docs/content/help/workflows/function-calling.mdx
             slug: function-calling-with-chat-models
+          - page: Examples & Walkthroughs
+            path: ./docs/content/help/workflows/examples-and-walkthroughs.mdx
+            slug: examples-and-walkthroughs
       - section: Evaluation & Test Suites
         contents:
           - page: Quantitative Evaluation

--- a/fern/docs/content/help/metrics/custom-metrics.mdx
+++ b/fern/docs/content/help/metrics/custom-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create Custom Reusable Metrics for LLM Evaluation in Vellum
+title: Create Custom Reusable Metrics for LLM Evaluation
 description: Learn how to create custom Metrics to evaluate your LLM Workflows with ease. Catch edge-cases, prevent regressions, and ship AI features faster with more confidence!
 ---
 

--- a/fern/docs/content/help/prompts/prompt-engineering-in-vellum.mdx
+++ b/fern/docs/content/help/prompts/prompt-engineering-in-vellum.mdx
@@ -1,5 +1,5 @@
 ---
-title: Prompt Engineering in Vellum
+title: Prompt Engineering
 description: Discover how Vellum's prompt engineering enhances LLMs with dynamic templates, jinja templating, and function calling for smarter prompts.
 image: https://storage.googleapis.com/vellum-public/help-docs/prompt_history.png
 ---

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -18,15 +18,55 @@ Concepts: Routing, Classification, Chatbot, Statefulness, State Management, Func
   />
 </Accordion>
 
-#### Customer Support Bot with Multiple Document Indexes
+#### Slack Support Bot, Cites Sources using Multiple Indexes
 
-Concepts: Document Indexes, Metadata, Zapier Integration, Citing Sources, Combining Sources 
+Concepts: Document Indexes, Metadata, Zapier, Slack, Citing Sources, Combining Sources 
 
-<Accordion title="Example Workflow">
-  <iframe
-    src="https://app.vellum.ai/public/workflow-deployments/788489db-7020-4167-b010-96499f7dd102"
-    width="100%"
-    height="450px"
-    experimental_enableRequestFullscreen={true}
-  />
-</Accordion>
+<AccordionGroup>
+  <Accordion title="Example Workflow">
+    <iframe
+      src="https://app.vellum.ai/public/workflow-deployments/788489db-7020-4167-b010-96499f7dd102"
+      width="100%"
+      height="450px"
+      experimental_enableRequestFullscreen={true}
+    />
+  </Accordion>
+  <Accordion title="Tip: Zapier API Calls">
+    Passing JSON Arrays in Zapier can be tricky. Instead, you can use Code Blocks to make it easier. 
+    
+    You can use the follow code snippet as inspiration for your own API calls with Zapier Code Blocks and Python.
+    ```python
+      import requests
+
+      # Replace with your actual Vellum API key
+      VELLUM_API_KEY = "..."
+
+      url = "https://predict.vellum.ai/v1/execute-workflow"
+
+      headers = {
+          "Content-Type": "application/json",
+          "X_API_KEY": VELLUM_API_KEY
+      }
+
+      data = {
+          "workflow_deployment_name": "<your-deployment-name>",
+          "release_tag": "LATEST",
+          "inputs": [
+              {
+                  "type": "STRING",
+                  "name": "<field_name>",
+                  "value": input_data["user_question"] # whatever Zapier values you want to use here
+              }
+          ]
+      }
+
+      response = requests.post(url, headers=headers, json=data)
+
+      # Print the response from the server
+      print(response.status_code)
+      print(response.json())
+
+      return response.json()
+    ```
+  </Accordion>
+</AccordionGroup>

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -1,3 +1,8 @@
+---
+title: Examples and Walkthroughs
+description: See interactive Vellum architectures and watch video walkthroughs of them! Use these as a great starting point for your own applications.
+---
+
 Below you'll find many example architectures for common use-cases, alongside video walkthroughs that explain the architecture of each. You're free to use these as a starting point for your own applications!
 
 #### Customer Support Bot with Escalation To Human

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -19,7 +19,7 @@ Concepts: Document Indexes, Metadata, Zapier Integration, Citing Sources, Combin
 
 <Accordion title="Example Workflow">
   <iframe
-    src="https://app.vellum.ai/public/workflow-deployments/03f75b7a-c76e-4bd2-a786-4ac21a298cc7"
+    src="https://app.vellum.ai/public/workflow-deployments/788489db-7020-4167-b010-96499f7dd102"
     width="100%"
     height="450px"
     experimental_enableRequestFullscreen={true}

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -11,7 +11,7 @@ Concepts: Routing, Classification, Chatbot, Statefulness, State Management, Func
 
 <Accordion title="Example Workflow">
   <iframe
-    src="https://app.vellum.ai/public/workflow-deployments/d5a345db-2676-4de1-9908-7e61e5089c81"
+    src="https://app.vellum.ai/public/workflow-deployments/aeb28969-e4c0-45fe-88a9-bf3fb7e79b76"
     width="100%"
     height="450px"
     experimental_enableRequestFullscreen={true}

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -7,7 +7,7 @@ Below you'll find many example architectures for common use-cases, alongside vid
 
 #### Customer Support Bot with Escalation To Human
 
-Concepts: Routing, Classification, Chatbot, Statefulness, State Management, Function Calling
+Concepts: Routing, Classification, Chatbot, Statefulness, State Management, Function Calling, Dynamic API URLs
 
 <Accordion title="Example Workflow">
   <iframe

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -1,0 +1,27 @@
+Below you'll find many example architectures for common use-cases, alongside video walkthroughs that explain the architecture of each. You're free to use these as a starting point for your own applications!
+
+#### Customer Support Bot with Escalation To Human
+
+Concepts: Routing, Classification, Chatbot, Statefulness, State Management, Function Calling
+
+<Accordion title="Example Workflow">
+  <iframe
+    src="https://app.vellum.ai/public/workflow-deployments/d5a345db-2676-4de1-9908-7e61e5089c81"
+    width="100%"
+    height="450px"
+    experimental_enableRequestFullscreen={true}
+  />
+</Accordion>
+
+#### Customer Support Bot with Multiple Document Indexes
+
+Concepts: Document Indexes, Metadata, Zapier Integration, Citing Sources, Combining Sources 
+
+<Accordion title="Example Workflow">
+  <iframe
+    src="https://app.vellum.ai/public/workflow-deployments/03f75b7a-c76e-4bd2-a786-4ac21a298cc7"
+    width="100%"
+    height="450px"
+    experimental_enableRequestFullscreen={true}
+  />
+</Accordion>

--- a/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
+++ b/fern/docs/content/help/workflows/examples-and-walkthroughs.mdx
@@ -49,12 +49,12 @@ Concepts: Document Indexes, Metadata, Zapier, Slack, Citing Sources, Combining S
       }
 
       data = {
-          "workflow_deployment_name": "<your-deployment-name>",
+          "workflow_deployment_name": "vellum-customer-support-q-a-demos",
           "release_tag": "LATEST",
           "inputs": [
               {
                   "type": "STRING",
-                  "name": "<field_name>",
+                  "name": "question",
                   "value": input_data["user_question"] # whatever Zapier values you want to use here
               }
           ]

--- a/fern/docs/content/help/workflows/function-calling.mdx
+++ b/fern/docs/content/help/workflows/function-calling.mdx
@@ -1,5 +1,5 @@
 ---
-title: Function Calling with Chat Models in Vellum
+title: Function Calling with Chat Models
 description: Learn how to use function calling with Chat Models in Vellum Workflows
 ---
 


### PR DESCRIPTION
Tired of thinking about how to organize docs pages— they're in a good spot now overall. 

This new section is just going to have tons of examples and keywords for concepts / industries on each one. 

See `/help-center/workflows/examples-and-walkthroughs` e.g. [preview link here](https://vellum-preview-85af0726-2558-4639-8e5a-25314c75850b.docs.buildwithfern.com/help-center/workflows/examples-and-walkthroughs)