### PR TITLE
hotfix: fix broken links by pinning evals & tests section slug

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -162,6 +162,7 @@ navigation:
             path: ./docs/content/help/workflows/examples-and-walkthroughs.mdx
             slug: examples-and-walkthroughs
       - section: Evaluation & Test Suites
+        slug: evaluation
         contents:
           - page: Quantitative Evaluation
             path: ./docs/content/help/evaluation/quantitatively-evaluating-outputs.mdx


### PR DESCRIPTION
alternatively, could setup redirects to fix broken links out in the wild, and could give google a sitemap so it can learn the new pages faster

but i prefer this approach (pinning the slug for this path) because i didn't intend to change the slugs here. there's debatable SEO impact of semantic slugs that's worth considering but for the volume of pages we have here i don't think it's too substantial

[context (i broke some links)](https://vellum-ai.slack.com/archives/C05608Q0VTQ/p1725403933635899) 😭