### PR TITLE
fix: API reference links for test case upserts

### DIFF
--- a/fern/docs/content/change-log/2024-06.mdx
+++ b/fern/docs/content/change-log/2024-06.mdx
@@ -106,7 +106,7 @@ Note: only the `score` output is aggregated and shown in the aggregate view.
 
 _June 6th, 2024_
 
-For a while now you've been able to programmatically [upsert](/api-reference/api-reference/test-suites/upsert-test-suite-test-case)
+For a while now you've been able to programmatically [upsert](/api-reference/test-suites/test-cases/upsert)
 and [delete](/api-reference/api-reference/test-suites/delete-test-suite-test-case) Test Cases in a Test suite individually.
 
 However, this can be problematic if you want to operate on many Test Cases at once. To solve this, we've added an API to create, replace, and delete Test Cases in bulk.

--- a/fern/docs/content/help/evaluation/quantitatively-evaluating-outputs.mdx
+++ b/fern/docs/content/help/evaluation/quantitatively-evaluating-outputs.mdx
@@ -122,7 +122,7 @@ Clicking that button will open a modal that allows you to bulk upload test cases
 
 ### Via API
 
-To upload test cases via API, check out the [Test Cases API](/api-reference/api-reference/test-suites/upsert-test-suite-test-case) documentation.
+To upload test cases via API, check out the [Test Cases API](/api-reference/test-suites/test-cases/upsert) documentation.
 
 ## Function Calling
 


### PR DESCRIPTION
as stated :) 

[requesting thread](https://vellum-ai.slack.com/archives/C05608Q0VTQ/p1726015592520169)

also, dang. looks like the original links had `test-case` at the end instead of `test-cases`. if it had the latter, it would've been caught by a redirect. rats 🐀 