### PR TITLE
Fix last broken links from evals docs refactor

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -103,6 +103,10 @@ redirects:
     destination: /api-reference/workflows/sandboxes/deploy
   - source: /help-center/workflows/experimentation#supported-node-types
     destination: /help-center/workflows/node-types
+  - source: /help-center/evaluation/workflow-evaluation-metric
+    destination: /help-center/metrics/custom-metrics#workflow-metric-using-llms-to-evaluate-llms
+  - source: /help-center/evaluation/code-execution-evaluation-metric
+    destination: /help-center/metrics/custom-metrics#code-execution-metric
 
 navigation:
   - tab: help


### PR DESCRIPTION
Whew, okay.. Sorry again for breaking these links in my evals refactor a few weeks back. Fwiw, one goal of that refactor is to free up space for more out-of-the-box metrics. Still on my radar for the technical writer contractor role :)

I think I backlogged this because there was an issue using redirects with anchors, but, confirmed that's not the case— just have to test redirects on preview URLs:
- https://vellum-preview-dde1ef4e-8343-4984-a19d-96796d8d8e6e.docs.buildwithfern.com/help-center/evaluation/workflow-evaluation-metric
- https://vellum-preview-dde1ef4e-8343-4984-a19d-96796d8d8e6e.docs.buildwithfern.com/help-center/evaluation/code-execution-evaluation-metric

And checked all eval paths that we link to from the main repo, so we should officially be good now:
![CleanShot 2024-09-13 at 16 05 06](https://github.com/user-attachments/assets/939ba1d0-d8f1-4192-9ea8-12b493e668f2)

@dvargas92495 -- do you have any context on webhook evaluation metrics though? https://docs.vellum.ai/help-center/evaluation/webhook-evaluation-metric. There are 4 references to it in the main repo but I can't find anything about it in the docs or in the product. 