### PR TITLE
Upgrade python sdk generator version

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -35,7 +35,7 @@ groups:
       - deprecated
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.0.0-rc2
+        version: 4.2.3
         api:
           settings:
             unions: v1


### PR DESCRIPTION
According to [fern](https://vellum-ai.slack.com/archives/C052UMCSFA8/p1726526565831029?thread_ts=1726526547.418909&cid=C052UMCSFA8), this will reduce the warnings we've been seeing as WaC (and likely our customers as well)