### PR TITLE
SDK Support for Recursive ARRAY Types

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -2017,6 +2017,19 @@ components:
       type: string
       enum:
       - ARRAY
+    ArrayVariableValue:
+      type: object
+      properties:
+        type:
+          type: string
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayVariableValueItem'
+          nullable: true
+      required:
+      - type
+      - value
     ArrayVariableValueItem:
       oneOf:
       - $ref: '#/components/schemas/StringVariableValue'
@@ -2025,6 +2038,9 @@ components:
       - $ref: '#/components/schemas/ErrorVariableValue'
       - $ref: '#/components/schemas/FunctionCallVariableValue'
       - $ref: '#/components/schemas/ImageVariableValue'
+      - $ref: '#/components/schemas/ChatHistoryVariableValue'
+      - $ref: '#/components/schemas/SearchResultsVariableValue'
+      - $ref: '#/components/schemas/ArrayVariableValue'
       discriminator:
         propertyName: type
         mapping:
@@ -2034,6 +2050,23 @@ components:
           ERROR: '#/components/schemas/ErrorVariableValue'
           FUNCTION_CALL: '#/components/schemas/FunctionCallVariableValue'
           IMAGE: '#/components/schemas/ImageVariableValue'
+          CHAT_HISTORY: '#/components/schemas/ChatHistoryVariableValue'
+          SEARCH_RESULTS: '#/components/schemas/SearchResultsVariableValue'
+          ARRAY: '#/components/schemas/ArrayVariableValue'
+    ArrayVellumValue:
+      type: object
+      description: A value representing an array of Vellum variable values.
+      properties:
+        type:
+          $ref: '#/components/schemas/ArrayEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayVellumValueItem'
+          nullable: true
+      required:
+      - type
+      - value
     ArrayVellumValueItem:
       oneOf:
       - $ref: '#/components/schemas/StringVellumValue'
@@ -2042,6 +2075,9 @@ components:
       - $ref: '#/components/schemas/ImageVellumValue'
       - $ref: '#/components/schemas/FunctionCallVellumValue'
       - $ref: '#/components/schemas/ErrorVellumValue'
+      - $ref: '#/components/schemas/ChatHistoryVellumValue'
+      - $ref: '#/components/schemas/SearchResultsVellumValue'
+      - $ref: '#/components/schemas/ArrayVellumValue'
       discriminator:
         propertyName: type
         mapping:
@@ -2051,6 +2087,9 @@ components:
           IMAGE: '#/components/schemas/ImageVellumValue'
           FUNCTION_CALL: '#/components/schemas/FunctionCallVellumValue'
           ERROR: '#/components/schemas/ErrorVellumValue'
+          CHAT_HISTORY: '#/components/schemas/ChatHistoryVellumValue'
+          SEARCH_RESULTS: '#/components/schemas/SearchResultsVellumValue'
+          ARRAY: '#/components/schemas/ArrayVellumValue'
     ArrayVellumValueItemRequest:
       oneOf:
       - $ref: '#/components/schemas/StringVellumValueRequest'
@@ -2059,6 +2098,9 @@ components:
       - $ref: '#/components/schemas/ImageVellumValueRequest'
       - $ref: '#/components/schemas/FunctionCallVellumValueRequest'
       - $ref: '#/components/schemas/ErrorVellumValueRequest'
+      - $ref: '#/components/schemas/ChatHistoryVellumValueRequest'
+      - $ref: '#/components/schemas/SearchResultsVellumValueRequest'
+      - $ref: '#/components/schemas/ArrayVellumValueRequest'
       discriminator:
         propertyName: type
         mapping:
@@ -2068,6 +2110,23 @@ components:
           IMAGE: '#/components/schemas/ImageVellumValueRequest'
           FUNCTION_CALL: '#/components/schemas/FunctionCallVellumValueRequest'
           ERROR: '#/components/schemas/ErrorVellumValueRequest'
+          CHAT_HISTORY: '#/components/schemas/ChatHistoryVellumValueRequest'
+          SEARCH_RESULTS: '#/components/schemas/SearchResultsVellumValueRequest'
+          ARRAY: '#/components/schemas/ArrayVellumValueRequest'
+    ArrayVellumValueRequest:
+      type: object
+      description: A value representing an array of Vellum variable values.
+      properties:
+        type:
+          $ref: '#/components/schemas/ArrayEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ArrayVellumValueItemRequest'
+          nullable: true
+      required:
+      - type
+      - value
     BasicVectorizerIntfloatMultilingualE5Large:
       type: object
       description: Basic vectorizer for intfloat/multilingual-e5-large.
@@ -2160,6 +2219,47 @@ components:
             $ref: '#/components/schemas/ChatMessageRequest'
       required:
       - name
+      - type
+      - value
+    ChatHistoryVariableValue:
+      type: object
+      properties:
+        type:
+          type: string
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessage'
+          nullable: true
+      required:
+      - type
+      - value
+    ChatHistoryVellumValue:
+      type: object
+      description: A value representing Chat History.
+      properties:
+        type:
+          $ref: '#/components/schemas/ChatHistoryEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessage'
+          nullable: true
+      required:
+      - type
+      - value
+    ChatHistoryVellumValueRequest:
+      type: object
+      description: A value representing Chat History.
+      properties:
+        type:
+          $ref: '#/components/schemas/ChatHistoryEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessageRequest'
+          nullable: true
+      required:
       - type
       - value
     ChatMessage:
@@ -6781,6 +6881,47 @@ components:
       type: string
       enum:
       - SEARCH_RESULTS
+    SearchResultsVariableValue:
+      type: object
+      properties:
+        type:
+          type: string
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchResult'
+          nullable: true
+      required:
+      - type
+      - value
+    SearchResultsVellumValue:
+      type: object
+      description: A value representing Search Results.
+      properties:
+        type:
+          $ref: '#/components/schemas/SearchResultsEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchResult'
+          nullable: true
+      required:
+      - type
+      - value
+    SearchResultsVellumValueRequest:
+      type: object
+      description: A value representing Search Results.
+      properties:
+        type:
+          $ref: '#/components/schemas/SearchResultsEnum'
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/SearchResultRequest'
+          nullable: true
+      required:
+      - type
+      - value
     SearchWeightsRequest:
       type: object
       properties:


### PR DESCRIPTION
I finally got this PR in to the main repo: https://github.com/vellum-ai/vellum/pull/5354

With this, we can now add sdk support for recursive vellum variable arrays.