### PR TITLE
Bump python sdk to 4.2.7

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -35,7 +35,7 @@ groups:
       - deprecated
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.2.6
+        version: 4.2.7
         api:
           settings:
             unions: v1


### PR DESCRIPTION
Context: https://vellum-ai.slack.com/archives/C052UMCSFA8/p1727885113563419?thread_ts=1727876390.026449&cid=C052UMCSFA8

TLDR, We want optional fields to be omitted from the API request sent to vellum