### PR TITLE
Quick OpenRouter Changelog Copy Tweaks

### DIFF
--- a/fern/docs/content/change-log/2024-10.mdx
+++ b/fern/docs/content/change-log/2024-10.mdx
@@ -23,18 +23,13 @@ Once configured, every execution of your Deployment will be evaluated against th
 For more details on how to get started with Online Evaluations, check out our [help documentation](/help-center/evaluation/online-evaluations).
 
 
-## New Model Host: OpenRouter
+## OpenRouter Model Hosting + WizardLM-2 8x22B
 
 __October 2nd, 2024__
 
 We've added OpenRouter as a new model host in Vellum! OpenRouter provides access to a wide range of AI models through a single API, expanding the options of models available to our users.
 
-
-### WizardLM Model Now Available
-
-As part of our OpenRouter integration, we're pleased to introduce the [WizardLM-2 8x22B](https://openrouter.ai/models/microsoft/wizardlm-2-8x22b) model to our platform. WizardLM-2 8x22B is known for its strong performance across various natural language processing tasks and is now available for use in your Vellum projects.
-
-These additions further expand the capabilities and flexibility of the Vellum platform, allowing you to leverage an even broader range of AI models for your applications.
+As part of our new OpenRouter integration, we're pleased to introduce the [WizardLM-2 8x22B](https://openrouter.ai/models/microsoft/wizardlm-2-8x22b) model to our platform. WizardLM-2 8x22B is known for its strong performance across various natural language processing tasks and is now available for use in your Vellum projects.
 
 ![OpenRouter Model Host](https://storage.googleapis.com/vellum-public/help-docs/changelogs/2024-10/open-router-model-host.png)
 


### PR DESCRIPTION
Makes some quick tweaks to this copy to:
1. Avoid nesting in our table of contents
<img width="261" alt="2024-10-03_19-45-19" src="https://github.com/user-attachments/assets/383a1eee-2b65-4f92-8f28-90454000bb87">

2. Remove this kinda salesy-sounding line "These additions further expand the capabilities and flexibility of the Vellum platform, allowing you to leverage an even broader range of AI models for your applications."