### PR TITLE
Update Spec to Allow `id` or `name` for Use w/ Test Suite APIs

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -1418,8 +1418,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       - name: limit
         required: false
@@ -1462,8 +1461,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       tags:
       - test-suites
@@ -1495,8 +1493,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       tags:
       - test-suites
@@ -1543,8 +1540,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       - in: path
         name: test_case_id
@@ -4791,6 +4787,8 @@ components:
           nullable: true
     MetadataFilterConfigRequest:
       type: object
+      description: A deprecated pattern for filtering on metadata. Please use MetadataFilters
+        instead.
       properties:
         combinator:
           allOf:


### PR DESCRIPTION
Adds support for either `id` or `name` in all Test Suite APIs.