### PR TITLE
Update API docs to include test suite reference by name 

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -721,37 +721,6 @@ paths:
       servers:
       - url: https://documents.vellum.ai
         x-name: Documents
-  /v1/execute-code:
-    post:
-      operationId: execute_code
-      description: An internal-only endpoint that's subject to breaking changes without
-        notice. Not intended for public use.
-      tags:
-      - execute-code
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CodeExecutorRequest'
-        required: true
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodeExecutorResponse'
-          description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodeExecutorErrorResponse'
-          description: ''
-      x-fern-availability: beta
-      x-fern-audiences:
-      - internal
   /v1/execute-prompt:
     post:
       operationId: execute_prompt

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -721,6 +721,37 @@ paths:
       servers:
       - url: https://documents.vellum.ai
         x-name: Documents
+  /v1/execute-code:
+    post:
+      operationId: execute_code
+      description: An internal-only endpoint that's subject to breaking changes without
+        notice. Not intended for public use.
+      tags:
+      - execute-code
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CodeExecutorRequest'
+        required: true
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeExecutorResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeExecutorErrorResponse'
+          description: ''
+      x-fern-availability: beta
+      x-fern-audiences:
+      - internal
   /v1/execute-prompt:
     post:
       operationId: execute_prompt
@@ -1418,8 +1449,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       - name: limit
         required: false
@@ -1462,8 +1492,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       tags:
       - test-suites
@@ -1495,8 +1524,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       tags:
       - test-suites
@@ -1543,8 +1571,7 @@ paths:
         name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this test suite.
+        description: Either the Test Suites' ID or its unique name
         required: true
       - in: path
         name: test_case_id

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "fern": "^0.0.19"
+      },
       "devDependencies": {
         "@cdktf/provider-generator": "^0.20.6",
         "ts-node": "^10.9.2"
@@ -570,6 +573,7 @@
     },
     "node_modules/cdktf/node_modules/archiver": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -587,6 +591,7 @@
     },
     "node_modules/cdktf/node_modules/archiver-utils": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -603,27 +608,32 @@
     },
     "node_modules/cdktf/node_modules/async": {
       "version": "3.2.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/b4a": {
       "version": "1.6.6",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/cdktf/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/bare-events": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/cdktf/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -632,6 +642,7 @@
     },
     "node_modules/cdktf/node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -640,6 +651,7 @@
     },
     "node_modules/cdktf/node_modules/call-bind": {
       "version": "1.0.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -658,6 +670,7 @@
     },
     "node_modules/cdktf/node_modules/compress-commons": {
       "version": "5.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -672,11 +685,13 @@
     },
     "node_modules/cdktf/node_modules/core-util-is": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/crc-32": {
       "version": "1.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "bin": {
@@ -688,6 +703,7 @@
     },
     "node_modules/cdktf/node_modules/crc32-stream": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -700,6 +716,7 @@
     },
     "node_modules/cdktf/node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -716,6 +733,7 @@
     },
     "node_modules/cdktf/node_modules/es-define-property": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -727,6 +745,7 @@
     },
     "node_modules/cdktf/node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -735,16 +754,19 @@
     },
     "node_modules/cdktf/node_modules/fast-fifo": {
       "version": "1.3.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/cdktf/node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "funding": {
@@ -753,6 +775,7 @@
     },
     "node_modules/cdktf/node_modules/get-intrinsic": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -771,6 +794,7 @@
     },
     "node_modules/cdktf/node_modules/glob": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -789,6 +813,7 @@
     },
     "node_modules/cdktf/node_modules/gopd": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -800,11 +825,13 @@
     },
     "node_modules/cdktf/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/cdktf/node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -816,6 +843,7 @@
     },
     "node_modules/cdktf/node_modules/has-proto": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -827,6 +855,7 @@
     },
     "node_modules/cdktf/node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -838,6 +867,7 @@
     },
     "node_modules/cdktf/node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -849,6 +879,7 @@
     },
     "node_modules/cdktf/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -858,16 +889,19 @@
     },
     "node_modules/cdktf/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/cdktf/node_modules/isarray": {
       "version": "2.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/json-stable-stringify": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -885,6 +919,7 @@
     },
     "node_modules/cdktf/node_modules/jsonify": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "Public Domain",
       "funding": {
@@ -893,6 +928,7 @@
     },
     "node_modules/cdktf/node_modules/lazystream": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -904,11 +940,13 @@
     },
     "node_modules/cdktf/node_modules/lazystream/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -923,11 +961,13 @@
     },
     "node_modules/cdktf/node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -936,11 +976,13 @@
     },
     "node_modules/cdktf/node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -952,6 +994,7 @@
     },
     "node_modules/cdktf/node_modules/minimatch": {
       "version": "5.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -963,6 +1006,7 @@
     },
     "node_modules/cdktf/node_modules/normalize-path": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -971,6 +1015,7 @@
     },
     "node_modules/cdktf/node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -979,6 +1024,7 @@
     },
     "node_modules/cdktf/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -987,16 +1033,19 @@
     },
     "node_modules/cdktf/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/queue-tick": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/readable-stream": {
       "version": "3.6.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1010,6 +1059,7 @@
     },
     "node_modules/cdktf/node_modules/readdir-glob": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1018,6 +1068,7 @@
     },
     "node_modules/cdktf/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1037,6 +1088,7 @@
     },
     "node_modules/cdktf/node_modules/semver": {
       "version": "7.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1051,6 +1103,7 @@
     },
     "node_modules/cdktf/node_modules/set-function-length": {
       "version": "1.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1067,6 +1120,7 @@
     },
     "node_modules/cdktf/node_modules/streamx": {
       "version": "2.16.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1079,6 +1133,7 @@
     },
     "node_modules/cdktf/node_modules/string_decoder": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1087,6 +1142,7 @@
     },
     "node_modules/cdktf/node_modules/tar-stream": {
       "version": "3.1.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1097,21 +1153,25 @@
     },
     "node_modules/cdktf/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/cdktf/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/cdktf/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/cdktf/node_modules/zip-stream": {
       "version": "5.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1485,6 +1545,15 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fern": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/fern/-/fern-0.0.19.tgz",
+      "integrity": "sha512-CBg9Kfpfy1JWz2JS0R5IM1mDUkySje8IazyrcByJ5Xihzn1bP3+LJFQAktCkKI2m7DgF6uItGwKskwKa//P60w==",
+      "license": "MIT",
+      "dependencies": {
+        "through": ">=2.3.4"
       }
     },
     "node_modules/fill-range": {
@@ -3100,6 +3169,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3896,6 +3970,7 @@
         "archiver": {
           "version": "6.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "archiver-utils": "^4.0.1",
             "async": "^3.2.4",
@@ -3909,6 +3984,7 @@
         "archiver-utils": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "^8.0.0",
             "graceful-fs": "^4.2.0",
@@ -3920,35 +3996,42 @@
         },
         "async": {
           "version": "3.2.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "b4a": {
           "version": "1.6.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bare-events": {
           "version": "2.2.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "buffer-crc32": {
           "version": "0.2.13",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "call-bind": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es-define-property": "^1.0.0",
             "es-errors": "^1.3.0",
@@ -3960,6 +4043,7 @@
         "compress-commons": {
           "version": "5.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "crc-32": "^1.2.0",
             "crc32-stream": "^5.0.0",
@@ -3969,15 +4053,18 @@
         },
         "core-util-is": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "crc-32": {
           "version": "1.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "crc32-stream": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "crc-32": "^1.2.0",
             "readable-stream": "^3.4.0"
@@ -3986,6 +4073,7 @@
         "define-data-property": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es-define-property": "^1.0.0",
             "es-errors": "^1.3.0",
@@ -3995,29 +4083,35 @@
         "es-define-property": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "get-intrinsic": "^1.2.4"
           }
         },
         "es-errors": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-fifo": {
           "version": "1.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "function-bind": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-intrinsic": {
           "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es-errors": "^1.3.0",
             "function-bind": "^1.1.2",
@@ -4029,6 +4123,7 @@
         "glob": {
           "version": "8.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4040,32 +4135,38 @@
         "gopd": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "get-intrinsic": "^1.1.3"
           }
         },
         "graceful-fs": {
           "version": "4.2.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-property-descriptors": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es-define-property": "^1.0.0"
           }
         },
         "has-proto": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-symbols": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hasown": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.2"
           }
@@ -4073,6 +4174,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -4080,15 +4182,18 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "2.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-stable-stringify": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "call-bind": "^1.0.5",
             "isarray": "^2.0.5",
@@ -4098,22 +4203,26 @@
         },
         "jsonify": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lazystream": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "readable-stream": "^2.0.5"
           },
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.8",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4126,11 +4235,13 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -4139,11 +4250,13 @@
         },
         "lodash": {
           "version": "4.17.21",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -4151,36 +4264,43 @@
         "minimatch": {
           "version": "5.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "normalize-path": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-keys": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "queue-tick": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "readable-stream": {
           "version": "3.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4190,17 +4310,20 @@
         "readdir-glob": {
           "version": "1.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimatch": "^5.1.0"
           }
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "7.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4208,6 +4331,7 @@
         "set-function-length": {
           "version": "1.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "define-data-property": "^1.1.4",
             "es-errors": "^1.3.0",
@@ -4220,6 +4344,7 @@
         "streamx": {
           "version": "2.16.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bare-events": "^2.2.0",
             "fast-fifo": "^1.1.0",
@@ -4229,6 +4354,7 @@
         "string_decoder": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
           }
@@ -4236,6 +4362,7 @@
         "tar-stream": {
           "version": "3.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "b4a": "^1.6.4",
             "fast-fifo": "^1.2.0",
@@ -4244,19 +4371,23 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "zip-stream": {
           "version": "5.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "archiver-utils": "^4.0.1",
             "compress-commons": "^5.0.1",
@@ -4537,6 +4668,14 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fern": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/fern/-/fern-0.0.19.tgz",
+      "integrity": "sha512-CBg9Kfpfy1JWz2JS0R5IM1mDUkySje8IazyrcByJ5Xihzn1bP3+LJFQAktCkKI2m7DgF6uItGwKskwKa//P60w==",
+      "requires": {
+        "through": ">=2.3.4"
       }
     },
     "fill-range": {
@@ -5737,6 +5876,11 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "devDependencies": {
     "@cdktf/provider-generator": "^0.20.6",
     "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "fern": "^0.0.19"
   }
 }


### PR DESCRIPTION
Previously, test suites could only be referenced by id. Now, they can be referenced by id or name and the API docs have been updated accordingly. 