### PR TITLE
bump node sdk version

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -10,7 +10,7 @@ groups:
       - deprecated
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.39.3
+        version: 0.40.8
         api:
           settings:
             unions: v1


### PR DESCRIPTION
<img width="570" alt="Screenshot 2024-10-11 at 4 55 49 PM" src="https://github.com/user-attachments/assets/7d23e41e-ebc0-4206-a364-2c7bc0c315ce">

This affected Sebi at redfin