### PR TITLE
Make `test_suite_run_id` Optional

### DIFF
--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -8403,7 +8403,6 @@ components:
           description: Configuration that defines how the Test Suite should be run
       required:
       - exec_config
-      - test_suite_id
     TestSuiteRunDeploymentReleaseTagExecConfig:
       type: object
       description: Execution configuration for running a Test Suite against a Prompt


### PR DESCRIPTION
This was a miss in a prior PR. This adds the support we're looking for.