### PR TITLE
add: missing image for rich text example

### DIFF
--- a/fern/docs/content/help/prompts/prompt-engineering-in-vellum.mdx
+++ b/fern/docs/content/help/prompts/prompt-engineering-in-vellum.mdx
@@ -33,6 +33,8 @@ variables by typing `{{ ` or `/` to get a dropdown of available variables.
 
 Here's an example of a Rich Text block:
 
+![Rich Text Block Example](https://storage.googleapis.com/vellum-public/help-docs/rich_text_block_example.png)
+
 
 ## Jinja Blocks
 


### PR DESCRIPTION
addresses [this](https://vellum-ai.slack.com/archives/C04SNUJ11L6/p1729108764222259). keepin' me on my toes

can preview [here](https://vellum-preview-9f6b3f08-37b6-4a4c-bcf0-f7624ee066b5.docs.buildwithfern.com/help-center/prompts/prompt-engineering#rich-text-blocks)